### PR TITLE
Add data driven styling capabilities 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ function evaluate(parameters, value) {
     } else if (parameters.type === 'categorical') {
         return evaluateCategorical(parameters, value);
     } else {
-        assert(false, 'Invalid scale type "' + parameters.type + '"');
+        assert(false, 'Invalid function type "' + parameters.type + '"');
     }
 }
 

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 module.exports = create;
 
-module.exports['interpolated'] = create;
+module.exports.interpolated = create;
 
 module.exports['piecewise-constant'] = function (parameters) {
     if (parameters.stops || parameters.range) {
@@ -11,7 +11,7 @@ module.exports['piecewise-constant'] = function (parameters) {
     }
 
     return create(parameters);
-}
+};
 
 function create(parameters) {
 
@@ -19,7 +19,7 @@ function create(parameters) {
     // occur and the output value is a constant.
     if (!(parameters.stops) && !(parameters.range)) {
         assert(parameters.rounding === undefined);
-        return function() { return parameters; }
+        return function() { return parameters; };
     }
 
     // If parameters.stops is specified, deconstruct it into a domain and range.
@@ -27,7 +27,7 @@ function create(parameters) {
         parameters.domain = [];
         parameters.range = [];
 
-        for (var i = 0; i <parameters.stops.length; i++) {
+        for (var i = 0; i < parameters.stops.length; i++) {
             parameters.domain.push(parameters.stops[i][0]);
             parameters.range.push(parameters.stops[i][1]);
         }
@@ -72,7 +72,8 @@ function create(parameters) {
         } else if (i === parameters.range.length || parameters.rounding === 'floor') {
             return parameters.range[i - 1];
 
-        } else if (parameters.rounding === 'none') {
+        } else {
+            assert(parameters.rounding === 'none');
             return interpolate(
                 input,
                 parameters.base,
@@ -81,11 +82,8 @@ function create(parameters) {
                 parameters.range[i - 1],
                 parameters.range[i]
             );
-
-        } else {
-            assert('false');
         }
-    }
+    };
 }
 
 function interpolate(input, base, inputLower, inputUpper, outputLower, outputUpper) {
@@ -119,7 +117,7 @@ function interpolateArray(input, base, inputLower, inputUpper, outputLower, outp
 }
 
 function clone(input) {
-    if (input === null || typeof(input) !== 'object') return input;
+    if (input === null || typeof input !== 'object') return input;
 
     var output = input.constructor();
 

--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ function evaluatePower(parameters, attribute) {
     assert(isNumeric(parameters.domain[0]));
 
     var base = parameters.base !== undefined ? parameters.base : 1;
-    var rounding = parameters.rounding || 'normal';
+    var rounding = parameters.rounding || 'none';
 
     var i = 0;
     while (true) {
@@ -74,7 +74,7 @@ function evaluatePower(parameters, attribute) {
         return parameters.range[i - 1];
 
     } else {
-        assert(rounding === 'normal');
+        assert(rounding === 'none');
         return interpolate(
             attribute,
             base,

--- a/index.js
+++ b/index.js
@@ -37,9 +37,7 @@ function create(parameters) {
 
     // END BACKWARDS COMPATIBILTY TRANSFORMATIONS
 
-    return function(zoom, attributes) {
-        assert(!attributes || typeof(attributes) === 'object');
-
+    return function() {
         assert(parameters.range.length === parameters.domain.length);
 
         if (parameters.property === undefined) parameters.property = '$zoom';
@@ -50,7 +48,16 @@ function create(parameters) {
         assert(parameters.range);
         assert(parameters.domain.length === parameters.range.length);
 
-        var input = parameters.property === '$zoom' ? zoom : attributes[parameters.property];
+        var input;
+        for (var j in arguments) {
+            if (arguments[j][parameters.property] !== undefined) {
+                input = arguments[j][parameters.property];
+            } else if (isFinite(arguments[j]) && parameters.property === '$zoom') {
+                input = arguments[j];
+            }
+        }
+
+        if (input === undefined) return parameters.range[0];
 
         // Find the first domain value larger than input
         var i = 0;

--- a/index.js
+++ b/index.js
@@ -37,17 +37,8 @@ function create(parameters) {
 
     // END BACKWARDS COMPATIBILTY TRANSFORMATIONS
 
-    return function(attributes) {
-
-        // START BACKWARDS COMPATIBILITY TRANSFORMATIONS
-
-        // If attributes is not an object, assume it is a zoom value, and create an attributes
-        // object out of it.
-        if (typeof(attributes) !== 'object') {
-            attributes = {'$zoom': attributes};
-        }
-
-        // END BACKWARDS COMPATIBILTY TRANSFORMATIONS
+    return function(zoom, attributes) {
+        assert(!attributes || typeof(attributes) === 'object');
 
         assert(parameters.range.length === parameters.domain.length);
 
@@ -59,7 +50,7 @@ function create(parameters) {
         assert(parameters.range);
         assert(parameters.domain.length === parameters.range.length);
 
-        var input = attributes[parameters.property];
+        var input = parameters.property === '$zoom' ? zoom : attributes[parameters.property];
 
         // Find the first domain value larger than input
         var i = 0;

--- a/index.js
+++ b/index.js
@@ -48,8 +48,10 @@ function create(parameters) {
         for (var j in arguments) {
             if (arguments[j][parameters.property] !== undefined) {
                 input = arguments[j][parameters.property];
+                break;
             } else if (isFinite(arguments[j]) && parameters.property === '$zoom') {
                 input = arguments[j];
+                break;
             }
         }
 

--- a/index.js
+++ b/index.js
@@ -37,19 +37,9 @@ function create(parameters) {
     assert(parameters.range);
     assert(parameters.domain.length === parameters.range.length);
 
-    return function() {
+    return function(attributes) {
 
-        // Find the input value
-        var input;
-        for (var j in arguments) {
-            if (arguments[j][parametersProperty] !== undefined) {
-                input = arguments[j][parametersProperty];
-                break;
-            } else if (isFinite(arguments[j]) && parametersProperty === '$zoom') {
-                input = arguments[j];
-                break;
-            }
-        }
+        var input = attributes[parametersProperty];
 
         if (input === undefined) return parameters.range[0];
 

--- a/index.js
+++ b/index.js
@@ -1,76 +1,45 @@
 'use strict';
 
+var GLOBAL_ATTRIBUTE_PREFIX = '$';
+
 module.exports = create;
-module.exports.migrate = migrate;
-module.exports.validate = validate;
-module.exports.is = isScale;
-
-function isScale(value) {
-    return isObject(value);
-}
-
-function migrate(parameters) {
-    parameters = clone(parameters);
-    if (parameters.stops) {
-        parameters.domain = [];
-        parameters.range = [];
-
-        for (var i = 0; i < parameters.stops.length; i++) {
-            parameters.domain.push(parameters.stops[i][0]);
-            parameters.range.push(parameters.stops[i][1]);
-        }
-
-        delete parameters.stops;
-    }
-
-    return parameters;
-}
-
-function validate(parameters) {
-    if (!isScale(parameters)) return;
-
-    assert(parameters.type, 'Scale must have a type of "power" or "ordinal"');
-    assert(!parameters.property || isString(parameters.property), 'Scale property parameter must be null or a string');
-    assert(parameters.domain, 'Scale must have a domain');
-    assert(parameters.range, 'Scale must have a range');
-    assert(parameters.domain.length === parameters.range.length, "Scale's domain must have the same number of domain elements as range elements");
-    assert(parameters.domain.length > 0, 'Scale must have more than 0 domain elements');
-
-    if (parameters.type === 'power') {
-        assert(!parameters.rounding || parameters.rounding === 'none'  || parameters.rounding === 'floor', 'Scale rounding parameter must be one of "none", or "floor"');
-        assert(!parameters.base || isNumeric(parameters.base), 'Scale base parameter must be null or a number');
-    }
-}
+module.exports.is = is;
 
 function create(parameters) {
-    validate(parameters);
-
-    // If the scale doesn't define a range, no interpolation will occur and the output value will be
-    // constant.
-    if (!isObject(parameters)) {
-        return function() { return function() { return parameters; }; };
-    }
-
     var property = parameters.property !== undefined ? parameters.property : '$zoom';
 
-    return function(attributes) {
-        var attribute = attributes[property];
-        if (attribute === undefined) {
-            return function(attributes) {
-                var attribute = attributes[property];
-                if (attribute === undefined) {
-                    return parameters.range[0];
-                } else {
-                    return evaluate(parameters, attribute);
-                }
-            };
+    var inner, outer;
+    if (!is(parameters)) {
+        inner = function() { return parameters; };
+        outer = function() { return inner; };
+        inner.isConstant = outer.isConstant = true;
 
-        } else {
-            return function() {
-                return evaluate(parameters, attribute);
-            };
-        }
-    };
+    } else if (property[0] === GLOBAL_ATTRIBUTE_PREFIX) {
+        outer = function(attributes) {
+            var value = evaluate(parameters, attributes[property]);
+            inner = function() { return value; };
+            inner.isConstant = true;
+            return inner;
+        };
+
+    } else {
+        outer = function() { return inner; };
+        inner = function(attributes) { return evaluate(parameters, attributes[property]); };
+    }
+
+    return outer;
+}
+
+function evaluate(parameters, attribute) {
+    if (attribute === undefined) {
+        return parameters.range[0];
+    } else if (parameters.type === 'power') {
+        return evaluatePower(parameters, attribute);
+    } else if (parameters.type === 'ordinal') {
+        return evaluateOrdinal(parameters, attribute);
+    } else {
+        assert(false);
+    }
 }
 
 function evaluateOrdinal(parameters, attribute) {
@@ -117,16 +86,6 @@ function evaluatePower(parameters, attribute) {
     }
 }
 
-function evaluate(parameters, attribute) {
-    if (parameters.type === 'power') {
-        return evaluatePower(parameters, attribute);
-    } else if (parameters.type === 'ordinal') {
-        return evaluateOrdinal(parameters, attribute);
-    } else {
-        assert(false);
-    }
-}
-
 function interpolate(input, base, inputLower, inputUpper, outputLower, outputUpper) {
     if (outputLower.length) {
         return interpolateArray(input, base, inputLower, inputUpper, outputLower, outputUpper);
@@ -157,6 +116,10 @@ function interpolateArray(input, base, inputLower, inputUpper, outputLower, outp
     return output;
 }
 
+function is(value) {
+    return typeof value === 'object' && !Array.isArray(value);
+}
+
 function isInterpolatable(value) {
     return isNumeric(value) || (Array.isArray(value) && isNumeric(value[0]));
 }
@@ -165,30 +128,8 @@ function isNumeric(value) {
     return !isNaN(parseFloat(value)) && isFinite(value);
 }
 
-function isObject(value) {
-    return typeof value === 'object' && !Array.isArray(value);
-}
-
-function isString(value) {
-    return typeof value === 'string';
-}
-
 function assert(predicate, message) {
     if (!predicate) {
         throw new Error(message || 'Assertion failed');
     }
-}
-
-function clone(input) {
-    if (input === null || typeof input !== 'object') return input;
-
-    var output = input.constructor();
-
-    for (var key in input) {
-        if (Object.prototype.hasOwnProperty.call(input, key)) {
-            output[key] = clone(input[key]);
-        }
-    }
-
-    return output;
 }

--- a/index.js
+++ b/index.js
@@ -48,11 +48,10 @@ function create(parameters) {
         while (true) {
             if (i >= parameters.domain.length) break;
             else if (input < parameters.domain[i]) break;
-            else if (parametersRounding === 'ceiling' && input === parameters.domain[i]) break;
             else i++;
         }
 
-        if (i === 0 || (parametersRounding === 'ceiling' && i < parameters.range.length)) {
+        if (i === 0) {
             return parameters.range[i];
 
         } else if (i === parameters.range.length || parametersRounding === 'floor') {

--- a/index.js
+++ b/index.js
@@ -33,17 +33,18 @@ function create(parameters) {
         }
     }
 
+    if (parameters.property === undefined) parameters.property = '$zoom';
+    if (parameters.rounding === undefined) parameters.rounding = 'none';
+    if (parameters.base === undefined) parameters.base = 1;
+
+    assert(parameters.range.length === parameters.domain.length);
+    assert(parameters.domain);
+    assert(parameters.range);
+    assert(parameters.domain.length === parameters.range.length);
+
     return function() {
-        assert(parameters.range.length === parameters.domain.length);
 
-        if (parameters.property === undefined) parameters.property = '$zoom';
-        if (parameters.rounding === undefined) parameters.rounding = 'none';
-        if (parameters.base === undefined) parameters.base = 1;
-
-        assert(parameters.domain);
-        assert(parameters.range);
-        assert(parameters.domain.length === parameters.range.length);
-
+        // Find the input value
         var input;
         for (var j in arguments) {
             if (arguments[j][parameters.property] !== undefined) {

--- a/index.js
+++ b/index.js
@@ -40,13 +40,24 @@ function create(parameters) {
     function evaluate(attribute) {
         // Find the first domain value larger than attribute
         var i = 0;
-        while (true) {
-            if (i >= parameters.domain.length) break;
-            else if (attribute < parameters.domain[i]) break;
-            else i++;
+
+        if (isNumeric(parameters.domain[0])) {
+            // Compare numbers using <
+            while (true) {
+                if (i >= parameters.domain.length) break;
+                else if (attribute < parameters.domain[i]) break;
+                else i++;
+            }
+        } else {
+            // Compare non-numbers using ===
+            while (true) {
+                if (i >= parameters.domain.length) break;
+                else if (attribute === parameters.domain[i]) break;
+                else i++;
+            }
         }
 
-        if (i === 0) {
+        if (i === 0 || !isNumeric(attribute)) {
             return parameters.range[i];
 
         } else if (i === parameters.range.length || parametersRounding === 'floor') {
@@ -118,6 +129,10 @@ function assert(predicate, message) {
     if (!predicate) {
         throw new Error(message || 'Assertion failed');
     }
+}
+
+function isNumeric(value) {
+    return !isNaN(parseFloat(value)) && isFinite(value);
 }
 
 function clone(input) {

--- a/index.js
+++ b/index.js
@@ -22,8 +22,6 @@ function create(parameters) {
         return function() { return parameters; }
     }
 
-    // START BACKWARDS COMPATIBILITY TRANSFORMATIONS
-
     // If parameters.stops is specified, deconstruct it into a domain and range.
     if (parameters.stops) {
         parameters.domain = [];
@@ -34,8 +32,6 @@ function create(parameters) {
             parameters.range.push(parameters.stops[i][1]);
         }
     }
-
-    // END BACKWARDS COMPATIBILTY TRANSFORMATIONS
 
     return function() {
         assert(parameters.range.length === parameters.domain.length);
@@ -68,7 +64,6 @@ function create(parameters) {
             else i++;
         }
 
-        // Interpolate to get the output
         if (i === 0 || (parameters.rounding === 'ceiling' && i < parameters.range.length)) {
             return parameters.range[i];
 
@@ -93,9 +88,9 @@ function create(parameters) {
 
 function interpolate(input, base, inputLower, inputUpper, outputLower, outputUpper) {
     if (outputLower.length) {
-        return interpolateArray.apply(this, arguments);
+        return interpolateArray(input, base, inputLower, inputUpper, outputLower, outputUpper);
     } else {
-        return interpolateNumber.apply(this, arguments);
+        return interpolateNumber(input, base, inputLower, inputUpper, outputLower, outputUpper);
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -3,8 +3,9 @@
   "version": "1.0.0",
   "description": "Evaluate a Mapbox GL style function",
   "devDependencies": {
-    "tape": "^3.5.0",
-    "eslint": "^0.22.1"
+    "eslint": "^0.22.1",
+    "mapbox-gl-style-spec": "git+https://github.com/mapbox/mapbox-gl-style-spec.git#v8-scales",
+    "tape": "^3.5.0"
   },
   "scripts": {
     "test": "eslint index.js test/*.js && tape test/*.js"

--- a/package.json
+++ b/package.json
@@ -2,12 +2,12 @@
   "name": "mapbox-gl-function",
   "version": "1.0.0",
   "description": "Evaluate a Mapbox GL style function",
-  "dependencies": {},
   "devDependencies": {
-    "tape": "^3.5.0"
+    "tape": "^3.5.0",
+    "eslint": "^0.22.1"
   },
   "scripts": {
-    "test": "tape test/*.js"
+    "test": "eslint index.js test/*.js && tape test/*.js"
   },
   "engines": {
     "node": "0.10.x"
@@ -16,5 +16,37 @@
     "type": "git",
     "url": "git@github.com:mapbox/mapbox-gl-function.git"
   },
-  "license": "ISC"
+  "license": "ISC",
+  "eslintConfig": {
+    "rules": {
+      "no-use-before-define": [
+        2,
+        "nofunc"
+      ],
+      "camelcase": 2,
+      "space-after-function-name": 2,
+      "space-in-parens": 2,
+      "space-before-blocks": 2,
+      "space-after-keywords": 2,
+      "comma-style": 2,
+      "no-lonely-if": 2,
+      "new-cap": 0,
+      "no-empty": 2,
+      "no-new": 2,
+      "no-multi-spaces": 0,
+      "space-in-brackets": 0,
+      "brace-style": 0,
+      "quotes": 0,
+      "no-underscore-dangle": 0,
+      "curly": 0,
+      "no-constant-condition": 0,
+      "no-native-reassign": 0,
+      "no-shadow": 0,
+      "key-spacing": 0
+    },
+    "env": {
+      "node": true,
+      "browser": true
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mapbox-gl-function",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Evaluate a Mapbox GL style function",
   "devDependencies": {
     "eslint": "^0.22.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Evaluate a Mapbox GL style function",
   "devDependencies": {
     "eslint": "^0.22.1",
-    "mapbox-gl-style-spec": "git+https://github.com/mapbox/mapbox-gl-style-spec.git#v8-scales",
+    "mapbox-gl-style-spec": "git+https://github.com/mapbox/mapbox-gl-style-spec.git#v8",
     "tape": "^3.5.0"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "tape": "^3.5.0"
   },
   "scripts": {
-    "test": "tape test.js"
+    "test": "tape test/*.js"
   },
   "engines": {
     "node": "0.10.x"

--- a/test/legacy.test.js
+++ b/test/legacy.test.js
@@ -8,7 +8,7 @@ var func = {
         var scale = MapboxGLScale(MapboxGLScale.migrate(parameters));
 
         return function(zoom) {
-            return scale({'$zoom': zoom});
+            return scale({'$zoom': zoom})({});
         };
     },
 

--- a/test/legacy.test.js
+++ b/test/legacy.test.js
@@ -5,7 +5,11 @@ var MapboxGLScale = require('../');
 
 var func = {
     interpolated: function(parameters) {
-        return MapboxGLScale(MapboxGLScale.migrate(parameters));
+        var scale = MapboxGLScale(MapboxGLScale.migrate(parameters));
+
+        return function(zoom) {
+            return scale({'$zoom': zoom});
+        };
     },
 
     'piecewise-constant': function (parameters) {
@@ -13,7 +17,8 @@ var func = {
             parameters = MapboxGLScale.migrate(parameters);
             parameters.rounding = 'floor';
         }
-        return MapboxGLScale(parameters);
+
+        return func.interpolated(parameters);
     }
 };
 

--- a/test/legacy.test.js
+++ b/test/legacy.test.js
@@ -2,11 +2,27 @@
 
 var test = require('tape');
 var MapboxGLScale = require('../');
+var MapboxGLStyleSpec = require('mapbox-gl-style-spec');
+
+function migrate(input) {
+
+    var inputStyle = {
+        version: 7,
+        layers: [{
+            id: 'mapbox',
+            paint: { 'line-color': input }
+        }]
+    };
+
+    var outputStyle = MapboxGLStyleSpec.migrate(inputStyle);
+
+    return outputStyle.layers[0].paint['line-color'];
+}
 
 var func = {
     interpolated: function(parameters) {
         if (parameters.stops) {
-            parameters = MapboxGLScale.migrate(parameters);
+            parameters = migrate(parameters);
             parameters.type = 'power';
         }
 
@@ -19,7 +35,7 @@ var func = {
 
     'piecewise-constant': function (parameters) {
         if (parameters.stops) {
-            parameters = MapboxGLScale.migrate(parameters);
+            parameters = migrate(parameters);
             parameters.type = 'power';
             parameters.rounding = 'floor';
         }

--- a/test/legacy.test.js
+++ b/test/legacy.test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var test = require('tape');
-var func = require('./');
+var func = require('../');
 
 test('interpolated, constant number', function(t) {
     var f = func.interpolated(0);

--- a/test/legacy.test.js
+++ b/test/legacy.test.js
@@ -5,7 +5,12 @@ var MapboxGLScale = require('../');
 
 var func = {
     interpolated: function(parameters) {
-        var scale = MapboxGLScale(MapboxGLScale.migrate(parameters));
+        if (parameters.stops) {
+            parameters = MapboxGLScale.migrate(parameters);
+            parameters.type = 'power';
+        }
+
+        var scale = MapboxGLScale(parameters);
 
         return function(zoom) {
             return scale({'$zoom': zoom})({});
@@ -15,10 +20,15 @@ var func = {
     'piecewise-constant': function (parameters) {
         if (parameters.stops) {
             parameters = MapboxGLScale.migrate(parameters);
+            parameters.type = 'power';
             parameters.rounding = 'floor';
         }
 
-        return func.interpolated(parameters);
+        var scale = MapboxGLScale(parameters);
+
+        return function(zoom) {
+            return scale({'$zoom': zoom})({});
+        };
     }
 };
 

--- a/test/legacy.test.js
+++ b/test/legacy.test.js
@@ -1,7 +1,21 @@
 'use strict';
 
 var test = require('tape');
-var func = require('../');
+var MapboxGLScale = require('../');
+
+var func = {
+    interpolated: function(parameters) {
+        return MapboxGLScale(MapboxGLScale.migrate(parameters));
+    },
+
+    'piecewise-constant': function (parameters) {
+        if (parameters.stops) {
+            parameters = MapboxGLScale.migrate(parameters);
+            parameters.rounding = 'floor';
+        }
+        return MapboxGLScale(parameters);
+    }
+};
 
 test('interpolated, constant number', function(t) {
     var f = func.interpolated(0);

--- a/test/test.js
+++ b/test/test.js
@@ -7,9 +7,9 @@ test('constant', function(t) {
     t.test('array', function(t) {
         var scale = MapboxGLScale([1]);
 
-        t.deepEqual(scale(0), [1]);
-        t.deepEqual(scale(1), [1]);
-        t.deepEqual(scale(2), [1]);
+        t.deepEqual(scale({'$zoom': 0}), [1]);
+        t.deepEqual(scale({'$zoom': 1}), [1]);
+        t.deepEqual(scale({'$zoom': 2}), [1]);
 
         t.end();
     });
@@ -17,9 +17,9 @@ test('constant', function(t) {
     t.test('number', function(t) {
         var scale = MapboxGLScale(1);
 
-        t.equal(scale(0), 1);
-        t.equal(scale(1), 1);
-        t.equal(scale(2), 1);
+        t.equal(scale({'$zoom': 0}), 1);
+        t.equal(scale({'$zoom': 1}), 1);
+        t.equal(scale({'$zoom': 2}), 1);
 
         t.end();
     });
@@ -34,9 +34,9 @@ test('domain & range', function(t) {
             range: [2]
         });
 
-        t.equal(scale(0), 2);
-        t.equal(scale(1), 2);
-        t.equal(scale(2), 2);
+        t.equal(scale({'$zoom': 0}), 2);
+        t.equal(scale({'$zoom': 1}), 2);
+        t.equal(scale({'$zoom': 2}), 2);
 
         t.end();
     });
@@ -47,11 +47,11 @@ test('domain & range', function(t) {
             range: [2, 6]
         });
 
-        t.equal(scale(0), 2);
-        t.equal(scale(1), 2);
-        t.equal(scale(2), 4);
-        t.equal(scale(3), 6);
-        t.equal(scale(4), 6);
+        t.equal(scale({'$zoom': 0}), 2);
+        t.equal(scale({'$zoom': 1}), 2);
+        t.equal(scale({'$zoom': 2}), 4);
+        t.equal(scale({'$zoom': 3}), 6);
+        t.equal(scale({'$zoom': 4}), 6);
 
         t.end();
     });
@@ -62,13 +62,13 @@ test('domain & range', function(t) {
             range: [2, 6, 10]
         });
 
-        t.equal(scale(0), 2);
-        t.equal(scale(1), 2);
-        t.equal(scale(2), 4);
-        t.equal(scale(3), 6);
-        t.equal(scale(4), 8);
-        t.equal(scale(5), 10);
-        t.equal(scale(6), 10);
+        t.equal(scale({'$zoom': 0}), 2);
+        t.equal(scale({'$zoom': 1}), 2);
+        t.equal(scale({'$zoom': 2}), 4);
+        t.equal(scale({'$zoom': 3}), 6);
+        t.equal(scale({'$zoom': 4}), 8);
+        t.equal(scale({'$zoom': 5}), 10);
+        t.equal(scale({'$zoom': 6}), 10);
 
         t.end();
     });
@@ -82,11 +82,11 @@ test('base', function(t) {
         base: 2
     });
 
-    t.equal(scale(0), 2);
-    t.equal(scale(1), 2);
-    t.equal(scale(2), 30 / 9);
-    t.equal(scale(3), 6);
-    t.equal(scale(4), 6);
+    t.equal(scale({'$zoom': 0}), 2);
+    t.equal(scale({'$zoom': 1}), 2);
+    t.equal(scale({'$zoom': 2}), 30 / 9);
+    t.equal(scale({'$zoom': 3}), 6);
+    t.equal(scale({'$zoom': 4}), 6);
 
     t.end();
 });
@@ -133,34 +133,6 @@ test('property', function(t) {
         t.end();
     });
 
-    t.test('$zoom from number', function(t) {
-        var scale = MapboxGLScale({
-            domain: [1, 3],
-            range: [2, 6],
-            property: '$zoom'
-        });
-
-        t.equal(scale(1), 2);
-        t.equal(scale(2), 4);
-        t.equal(scale(3), 6);
-
-        t.end();
-    });
-
-    t.test('$zoom from object', function(t) {
-        var scale = MapboxGLScale({
-            domain: [1, 3],
-            range: [2, 6],
-            property: '$zoom'
-        });
-
-        t.equal(scale({'$zoom': 1}), 2);
-        t.equal(scale({'$zoom': 2}), 4);
-        t.equal(scale({'$zoom': 3}), 6);
-
-        t.end();
-    });
-
     t.end();
 });
 
@@ -179,30 +151,6 @@ test('attribute arguments', function(t) {
         t.end();
     });
 
-    t.test('object, number', function(t) {
-        var scale = MapboxGLScale({
-            domain: [1, 3],
-            range: [2, 6],
-            property: 'mapbox'
-        });
-
-        t.equal(scale(3, {mapbox: 1}), 2);
-
-        t.end();
-    });
-
-    t.test('object, number', function(t) {
-        var scale = MapboxGLScale({
-            domain: [1, 3],
-            range: [2, 6],
-            property: 'mapbox'
-        });
-
-        t.equal(scale({mapbox: 1}, 3), 2);
-
-        t.end();
-    });
-
 });
 
 test('rounding', function(t) {
@@ -214,13 +162,13 @@ test('rounding', function(t) {
             rounding: 'none'
         });
 
-        t.equal(scale(0), 2);
-        t.equal(scale(1), 2);
-        t.equal(scale(1.9), 1.9 * 2);
-        t.equal(scale(2), 4);
-        t.equal(scale(2.1), 2.1 * 2);
-        t.equal(scale(3), 6);
-        t.equal(scale(4), 6);
+        t.equal(scale({'$zoom': 0}), 2);
+        t.equal(scale({'$zoom': 1}), 2);
+        t.equal(scale({'$zoom': 1.9}), 1.9 * 2);
+        t.equal(scale({'$zoom': 2}), 4);
+        t.equal(scale({'$zoom': 2.1}), 2.1 * 2);
+        t.equal(scale({'$zoom': 3}), 6);
+        t.equal(scale({'$zoom': 4}), 6);
 
         t.end();
     });
@@ -232,11 +180,11 @@ test('rounding', function(t) {
             rounding: 'floor'
         });
 
-        t.equal(scale(0), 2);
-        t.equal(scale(1), 2);
-        t.equal(scale(2), 2);
-        t.equal(scale(3), 6);
-        t.equal(scale(4), 6);
+        t.equal(scale({'$zoom': 0}), 2);
+        t.equal(scale({'$zoom': 1}), 2);
+        t.equal(scale({'$zoom': 2}), 2);
+        t.equal(scale({'$zoom': 3}), 6);
+        t.equal(scale({'$zoom': 4}), 6);
 
         t.end();
     });
@@ -248,11 +196,11 @@ test('rounding', function(t) {
             rounding: 'ceiling'
         });
 
-        t.equal(scale(0), 2);
-        t.equal(scale(1), 2);
-        t.equal(scale(2), 6);
-        t.equal(scale(3), 6);
-        t.equal(scale(4), 6);
+        t.equal(scale({'$zoom': 0}), 2);
+        t.equal(scale({'$zoom': 1}), 2);
+        t.equal(scale({'$zoom': 2}), 6);
+        t.equal(scale({'$zoom': 3}), 6);
+        t.equal(scale({'$zoom': 4}), 6);
 
         t.end();
     });

--- a/test/test.js
+++ b/test/test.js
@@ -32,6 +32,12 @@ test('scale isConstant', function(t) {
         t.ok(scale.isConstant);
         t.ok(scale({}).isConstant);
 
+        t.ok(scale.isGlobalConstant);
+        t.ok(scale({}).isGlobalConstant);
+
+        t.ok(scale.isFeatureConstant);
+        t.ok(scale({}).isFeatureConstant);
+
         t.end();
     });
 
@@ -45,6 +51,12 @@ test('scale isConstant', function(t) {
         t.notOk(scale.isConstant);
         t.ok(scale({}).isConstant);
 
+        t.notOk(scale.isGlobalConstant);
+        t.notOk(scale({}).isGlobalConstant);
+
+        t.ok(scale.isFeatureConstant);
+        t.ok(scale({}).isFeatureConstant);
+
         t.end();
     });
 
@@ -57,6 +69,12 @@ test('scale isConstant', function(t) {
 
         t.notOk(scale.isConstant);
         t.notOk(scale({}).isConstant);
+
+        t.notOk(scale.isGlobalConstant);
+        t.notOk(scale({}).isGlobalConstant);
+
+        t.notOk(scale.isFeatureConstant);
+        t.notOk(scale({}).isFeatureConstant);
 
         t.end();
     });

--- a/test/test.js
+++ b/test/test.js
@@ -23,6 +23,43 @@ test('constant type', function(t) {
 
         t.end();
     });
+});
+
+test('scale isConstant', function(t) {
+    t.test('constant', function(t) {
+        var scale = MapboxGLScale(1);
+
+        t.equal(scale.isConstant, true);
+        t.equal(scale({}).isConstant, true);
+
+        t.end();
+    });
+
+    t.test('global', function(t) {
+        var scale = MapboxGLScale({
+            domain: [1],
+            range: [1],
+            property: '$zoom'
+        });
+
+        t.notOk(scale.isConstant);
+        t.equal(scale({}).isConstant, true);
+
+        t.end();
+    });
+
+    t.test('feature', function(t) {
+        var scale = MapboxGLScale({
+            domain: [1],
+            range: [1],
+            property: 'mapbox'
+        });
+
+        t.notOk(scale.isConstant);
+        t.notOk(scale({}).isConstant);
+
+        t.end();
+    });
 
     t.end();
 });
@@ -50,7 +87,7 @@ test('property', function(t) {
             property: 'mapbox'
         });
 
-        t.equal(scale({mapbox: 'box'})({}), 'swell');
+        t.equal(scale({})({mapbox: 'box'}), 'swell');
 
         t.end();
     });
@@ -83,8 +120,8 @@ test('ordinal type', function(t) {
                 property: 'mapbox'
             });
 
-            t.equal(scale({'mapbox': 'umpteen'})({}), 42);
-            t.equal(scale({'mapbox': 'derp'})({}), 42);
+            t.equal(scale({})({mapbox: 'umpteen'}), 42);
+            t.equal(scale({})({mapbox: 'derp'}), 42);
 
             t.end();
         });
@@ -97,8 +134,8 @@ test('ordinal type', function(t) {
                 property: 'mapbox'
             });
 
-            t.equal(scale({'mapbox': 'umpteen'})({}), 42);
-            t.equal(scale({'mapbox': 'eleventy'})({}), 110);
+            t.equal(scale({})({mapbox: 'umpteen'}), 42);
+            t.equal(scale({})({mapbox: 'eleventy'}), 110);
 
             t.end();
         });
@@ -111,9 +148,9 @@ test('ordinal type', function(t) {
                 property: 'mapbox'
             });
 
-            t.equal(scale({'mapbox': 'umpteen'})({}), 42);
-            t.equal(scale({'mapbox': 'eleventy'})({}), 110);
-            t.equal(scale({'mapbox': 'bunch'})({}), 17);
+            t.equal(scale({})({mapbox: 'umpteen'}), 42);
+            t.equal(scale({})({mapbox: 'eleventy'}), 110);
+            t.equal(scale({})({mapbox: 'bunch'}), 17);
 
             t.end();
         });
@@ -130,8 +167,8 @@ test('ordinal type', function(t) {
                 property: 'mapbox'
             });
 
-            t.equal(scale({mapbox: 1})({}), 2);
-            t.equal(scale({mapbox: 3})({}), 6);
+            t.equal(scale({})({mapbox: 1}), 2);
+            t.equal(scale({})({mapbox: 3}), 6);
 
             t.end();
         });
@@ -144,8 +181,8 @@ test('ordinal type', function(t) {
                 property: 'mapbox'
             });
 
-            t.equal(scale({mapbox: 1})({}), 'a');
-            t.equal(scale({mapbox: 3})({}), 'c');
+            t.equal(scale({})({mapbox: 1}), 'a');
+            t.equal(scale({})({mapbox: 3}), 'c');
 
             t.end();
         });
@@ -158,8 +195,8 @@ test('ordinal type', function(t) {
                 property: 'mapbox'
             });
 
-            t.equal(scale({mapbox: 1})({}), true);
-            t.equal(scale({mapbox: 3})({}), false);
+            t.equal(scale({})({mapbox: 1}), true);
+            t.equal(scale({})({mapbox: 3}), false);
 
             t.end();
         });
@@ -177,8 +214,8 @@ test('ordinal type', function(t) {
                 property: 'mapbox'
             });
 
-            t.equal(scale({mapbox: 1})({}), 2);
-            t.equal(scale({mapbox: 3})({}), 6);
+            t.equal(scale({})({mapbox: 1}), 2);
+            t.equal(scale({})({mapbox: 3}), 6);
 
             t.end();
         });
@@ -191,8 +228,8 @@ test('ordinal type', function(t) {
                 property: 'mapbox'
             });
 
-            t.equal(scale({mapbox: 'a'})({}), 2);
-            t.equal(scale({mapbox: 'c'})({}), 6);
+            t.equal(scale({})({mapbox: 'a'}), 2);
+            t.equal(scale({})({mapbox: 'c'}), 6);
 
             t.end();
         });
@@ -205,8 +242,8 @@ test('ordinal type', function(t) {
                 property: 'mapbox'
             });
 
-            t.equal(scale({mapbox: true})({}), 2);
-            t.equal(scale({mapbox: false})({}), 6);
+            t.equal(scale({})({mapbox: true}), 2);
+            t.equal(scale({})({mapbox: false}), 6);
 
             t.end();
         });
@@ -235,7 +272,6 @@ test('power type', function(t) {
 
         t.end();
     });
-
 
     t.test('domain & range', function(t) {
         t.test('one element', function(t) {
@@ -286,6 +322,55 @@ test('power type', function(t) {
             t.end();
         });
 
+    });
+
+    t.test('range types', function(t) {
+
+        t.test('number', function(t) {
+            var scale = MapboxGLScale({
+                type: 'power',
+                domain: [1, 3],
+                range: [2, 6],
+                property: 'mapbox'
+            });
+
+            t.equal(scale({})({mapbox: 1}), 2);
+            t.equal(scale({})({mapbox: 3}), 6);
+
+            t.end();
+        });
+
+        t.test('string', function(t) {
+            var scale = MapboxGLScale({
+                type: 'power',
+                domain: [1, 3],
+                range: ['a', 'c'],
+                rounding: 'floor',
+                property: 'mapbox'
+            });
+
+            t.equal(scale({})({mapbox: 1}), 'a');
+            t.equal(scale({})({mapbox: 3}), 'c');
+
+            t.end();
+        });
+
+        t.test('boolean', function(t) {
+            var scale = MapboxGLScale({
+                type: 'power',
+                domain: [1, 3],
+                range: [true, false],
+                rounding: 'floor',
+                property: 'mapbox'
+            });
+
+            t.equal(scale({})({mapbox: 1}), true);
+            t.equal(scale({})({mapbox: 3}), false);
+
+            t.end();
+        });
+
+        t.end();
     });
 
 });

--- a/test/test.js
+++ b/test/test.js
@@ -220,3 +220,47 @@ test('rounding', function(t) {
 
     t.end();
 });
+
+test('domain types', function(t) {
+
+    t.test('number', function(t) {
+        var scale = MapboxGLScale({
+            domain: [1, 3],
+            range: [2, 6],
+            property: 'mapbox'
+        });
+
+        t.equal(scale({mapbox: 1})({}), 2);
+        t.equal(scale({mapbox: 3})({}), 6);
+
+        t.end();
+    });
+
+    t.test('string', function(t) {
+        var scale = MapboxGLScale({
+            domain: ['a', 'c'],
+            range: [2, 6],
+            property: 'mapbox'
+        });
+
+        t.equal(scale({mapbox: 'a'})({}), 2);
+        t.equal(scale({mapbox: 'c'})({}), 6);
+
+        t.end();
+    });
+
+    t.test('boolean', function(t) {
+        var scale = MapboxGLScale({
+            domain: [true, false],
+            range: [2, 6],
+            property: 'mapbox'
+        });
+
+        t.equal(scale({mapbox: true})({}), 2);
+        t.equal(scale({mapbox: false})({}), 6);
+
+        t.end();
+    });
+
+    t.end();
+});

--- a/test/test.js
+++ b/test/test.js
@@ -3,38 +3,38 @@
 var test = require('tape');
 var MapboxGLScale = require('../');
 
-test('scale types', function(t) {
+test('function types', function(t) {
 
     t.test('contant', function(t) {
 
         t.test('range types', function(t) {
 
             t.test('array', function(t) {
-                var scale = MapboxGLScale([1]);
+                var f = MapboxGLScale([1]);
 
-                t.deepEqual(scale({'$zoom': 0})({}), [1]);
-                t.deepEqual(scale({'$zoom': 1})({}), [1]);
-                t.deepEqual(scale({'$zoom': 2})({}), [1]);
+                t.deepEqual(f({'$zoom': 0})({}), [1]);
+                t.deepEqual(f({'$zoom': 1})({}), [1]);
+                t.deepEqual(f({'$zoom': 2})({}), [1]);
 
                 t.end();
             });
 
             t.test('number', function(t) {
-                var scale = MapboxGLScale(1);
+                var f = MapboxGLScale(1);
 
-                t.equal(scale({'$zoom': 0})({}), 1);
-                t.equal(scale({'$zoom': 1})({}), 1);
-                t.equal(scale({'$zoom': 2})({}), 1);
+                t.equal(f({'$zoom': 0})({}), 1);
+                t.equal(f({'$zoom': 1})({}), 1);
+                t.equal(f({'$zoom': 2})({}), 1);
 
                 t.end();
             });
 
             t.test('string', function(t) {
-                var scale = MapboxGLScale('mapbox');
+                var f = MapboxGLScale('mapbox');
 
-                t.equal(scale({'$zoom': 0})({}), 'mapbox');
-                t.equal(scale({'$zoom': 1})({}), 'mapbox');
-                t.equal(scale({'$zoom': 2})({}), 'mapbox');
+                t.equal(f({'$zoom': 0})({}), 'mapbox');
+                t.equal(f({'$zoom': 1})({}), 'mapbox');
+                t.equal(f({'$zoom': 2})({}), 'mapbox');
 
                 t.end();
             });
@@ -43,75 +43,70 @@ test('scale types', function(t) {
 
     });
 
-    t.test('interval', function(t) {
-        // TODO @nocommit
-        t.end();
-    });
-
     t.test('exponential', function(t) {
 
         t.test('base', function(t) {
-            var scale = MapboxGLScale({
+            var f = MapboxGLScale({
                 type: 'exponential',
                 domain: [1, 3],
                 range: [2, 6],
                 base: 2
             });
 
-            t.equal(scale({'$zoom': 0})({}), 2);
-            t.equal(scale({'$zoom': 1})({}), 2);
-            t.equal(scale({'$zoom': 2})({}), 30 / 9);
-            t.equal(scale({'$zoom': 3})({}), 6);
-            t.equal(scale({'$zoom': 4})({}), 6);
+            t.equal(f({'$zoom': 0})({}), 2);
+            t.equal(f({'$zoom': 1})({}), 2);
+            t.equal(f({'$zoom': 2})({}), 30 / 9);
+            t.equal(f({'$zoom': 3})({}), 6);
+            t.equal(f({'$zoom': 4})({}), 6);
 
             t.end();
         });
 
         t.test('domain & range', function(t) {
             t.test('one element', function(t) {
-                var scale = MapboxGLScale({
+                var f = MapboxGLScale({
                     type: 'exponential',
                     domain: [1],
                     range: [2]
                 });
 
-                t.equal(scale({'$zoom': 0})({}), 2);
-                t.equal(scale({'$zoom': 1})({}), 2);
-                t.equal(scale({'$zoom': 2})({}), 2);
+                t.equal(f({'$zoom': 0})({}), 2);
+                t.equal(f({'$zoom': 1})({}), 2);
+                t.equal(f({'$zoom': 2})({}), 2);
 
                 t.end();
             });
 
             t.test('two elements', function(t) {
-                var scale = MapboxGLScale({
+                var f = MapboxGLScale({
                     type: 'exponential',
                     domain: [1, 3],
                     range: [2, 6]
                 });
 
-                t.equal(scale({'$zoom': 0})({}), 2);
-                t.equal(scale({'$zoom': 1})({}), 2);
-                t.equal(scale({'$zoom': 2})({}), 4);
-                t.equal(scale({'$zoom': 3})({}), 6);
-                t.equal(scale({'$zoom': 4})({}), 6);
+                t.equal(f({'$zoom': 0})({}), 2);
+                t.equal(f({'$zoom': 1})({}), 2);
+                t.equal(f({'$zoom': 2})({}), 4);
+                t.equal(f({'$zoom': 3})({}), 6);
+                t.equal(f({'$zoom': 4})({}), 6);
 
                 t.end();
             });
 
             t.test('three elements', function(t) {
-                var scale = MapboxGLScale({
+                var f = MapboxGLScale({
                     type: 'exponential',
                     domain: [1, 3, 5],
                     range: [2, 6, 10]
                 });
 
-                t.equal(scale({'$zoom': 0})({}), 2);
-                t.equal(scale({'$zoom': 1})({}), 2);
-                t.equal(scale({'$zoom': 2})({}), 4);
-                t.equal(scale({'$zoom': 3})({}), 6);
-                t.equal(scale({'$zoom': 4})({}), 8);
-                t.equal(scale({'$zoom': 5})({}), 10);
-                t.equal(scale({'$zoom': 6})({}), 10);
+                t.equal(f({'$zoom': 0})({}), 2);
+                t.equal(f({'$zoom': 1})({}), 2);
+                t.equal(f({'$zoom': 2})({}), 4);
+                t.equal(f({'$zoom': 3})({}), 6);
+                t.equal(f({'$zoom': 4})({}), 8);
+                t.equal(f({'$zoom': 5})({}), 10);
+                t.equal(f({'$zoom': 6})({}), 10);
 
                 t.end();
             });
@@ -123,30 +118,30 @@ test('scale types', function(t) {
     t.test('categorical', function(t) {
 
         t.test('one element', function(t) {
-            var scale = MapboxGLScale({
+            var f = MapboxGLScale({
                 type: 'categorical',
                 domain: ['umpteen'],
                 range: [42],
                 property: 'mapbox'
             });
 
-            t.equal(scale({})({mapbox: 'umpteen'}), 42);
-            t.equal(scale({})({mapbox: 'derp'}), 42);
+            t.equal(f({})({mapbox: 'umpteen'}), 42);
+            t.equal(f({})({mapbox: 'derp'}), 42);
 
             t.end();
         });
 
         t.test('two elements', function(t) {
-            var scale = MapboxGLScale({
+            var f = MapboxGLScale({
                 type: 'categorical',
                 domain: ['umpteen', 'eleventy'],
                 range: [42, 110],
                 property: 'mapbox'
             });
 
-            t.equal(scale({})({mapbox: 'umpteen'}), 42);
-            t.equal(scale({})({mapbox: 'eleventy'}), 110);
-            t.equal(scale({})({mapbox: 'derp'}), 42);
+            t.equal(f({})({mapbox: 'umpteen'}), 42);
+            t.equal(f({})({mapbox: 'eleventy'}), 110);
+            t.equal(f({})({mapbox: 'derp'}), 42);
 
 
             t.end();
@@ -157,33 +152,33 @@ test('scale types', function(t) {
     t.test('interval', function(t) {
 
         t.test('one domain element', function(t) {
-            var scale = MapboxGLScale({
+            var f = MapboxGLScale({
                 type: 'interval',
                 domain: [0],
                 range: [11, 111],
                 property: 'mapbox'
             });
 
-            t.equal(scale({})({mapbox: -0.5}), 11);
-            t.equal(scale({})({mapbox: 0}), 111);
-            t.equal(scale({})({mapbox: 0.5}), 111);
+            t.equal(f({})({mapbox: -0.5}), 11);
+            t.equal(f({})({mapbox: 0}), 111);
+            t.equal(f({})({mapbox: 0.5}), 111);
 
             t.end();
         });
 
         t.test('two domain elements', function(t) {
-            var scale = MapboxGLScale({
+            var f = MapboxGLScale({
                 type: 'interval',
                 domain: [0, 1],
                 range: [11, 111, 1111],
                 property: 'mapbox'
             });
 
-            t.equal(scale({})({mapbox: -0.5}), 11);
-            t.equal(scale({})({mapbox: 0}), 111);
-            t.equal(scale({})({mapbox: 0.5}), 111);
-            t.equal(scale({})({mapbox: 1}), 1111);
-            t.equal(scale({})({mapbox: 1.5}), 1111);
+            t.equal(f({})({mapbox: -0.5}), 11);
+            t.equal(f({})({mapbox: 0}), 111);
+            t.equal(f({})({mapbox: 0.5}), 111);
+            t.equal(f({})({mapbox: 1}), 1111);
+            t.equal(f({})({mapbox: 1.5}), 1111);
 
             t.end();
         });
@@ -195,40 +190,40 @@ test('scale types', function(t) {
 test('property', function(t) {
 
     t.test('missing property', function(t) {
-        var scale = MapboxGLScale({
+        var f = MapboxGLScale({
             type: 'categorical',
             domain: ['map', 'box'],
             range: ['neat', 'swell'],
             property: 'mapbox'
         });
 
-        t.equal(scale({})({}), 'neat');
+        t.equal(f({})({}), 'neat');
 
         t.end();
     });
 
     t.test('global property', function(t) {
-        var scale = MapboxGLScale({
+        var f = MapboxGLScale({
             type: 'categorical',
             domain: ['map', 'box'],
             range: ['neat', 'swell'],
             property: 'mapbox'
         });
 
-        t.equal(scale({})({mapbox: 'box'}), 'swell');
+        t.equal(f({})({mapbox: 'box'}), 'swell');
 
         t.end();
     });
 
     t.test('feature property', function(t) {
-        var scale = MapboxGLScale({
+        var f = MapboxGLScale({
             type: 'categorical',
             domain: ['map', 'box'],
             range: ['neat', 'swell'],
             property: 'mapbox'
         });
 
-        t.equal(scale({})({mapbox: 'box'}), 'swell');
+        t.equal(f({})({mapbox: 'box'}), 'swell');
 
         t.end();
     });
@@ -239,54 +234,54 @@ test('property', function(t) {
 test('isConstant', function(t) {
 
     t.test('constant', function(t) {
-        var scale = MapboxGLScale(1);
+        var f = MapboxGLScale(1);
 
-        t.ok(scale.isConstant);
-        t.ok(scale({}).isConstant);
+        t.ok(f.isConstant);
+        t.ok(f({}).isConstant);
 
-        t.ok(scale.isGlobalConstant);
-        t.ok(scale({}).isGlobalConstant);
+        t.ok(f.isGlobalConstant);
+        t.ok(f({}).isGlobalConstant);
 
-        t.ok(scale.isFeatureConstant);
-        t.ok(scale({}).isFeatureConstant);
+        t.ok(f.isFeatureConstant);
+        t.ok(f({}).isFeatureConstant);
 
         t.end();
     });
 
     t.test('global', function(t) {
-        var scale = MapboxGLScale({
+        var f = MapboxGLScale({
             domain: [1],
             range: [1],
             property: '$zoom'
         });
 
-        t.notOk(scale.isConstant);
-        t.ok(scale({}).isConstant);
+        t.notOk(f.isConstant);
+        t.ok(f({}).isConstant);
 
-        t.notOk(scale.isGlobalConstant);
-        t.notOk(scale({}).isGlobalConstant);
+        t.notOk(f.isGlobalConstant);
+        t.notOk(f({}).isGlobalConstant);
 
-        t.ok(scale.isFeatureConstant);
-        t.ok(scale({}).isFeatureConstant);
+        t.ok(f.isFeatureConstant);
+        t.ok(f({}).isFeatureConstant);
 
         t.end();
     });
 
     t.test('feature', function(t) {
-        var scale = MapboxGLScale({
+        var f = MapboxGLScale({
             domain: [1],
             range: [1],
             property: 'mapbox'
         });
 
-        t.notOk(scale.isConstant);
-        t.notOk(scale({}).isConstant);
+        t.notOk(f.isConstant);
+        t.notOk(f({}).isConstant);
 
-        t.notOk(scale.isGlobalConstant);
-        t.notOk(scale({}).isGlobalConstant);
+        t.notOk(f.isGlobalConstant);
+        t.notOk(f({}).isGlobalConstant);
 
-        t.notOk(scale.isFeatureConstant);
-        t.notOk(scale({}).isFeatureConstant);
+        t.notOk(f.isFeatureConstant);
+        t.notOk(f({}).isFeatureConstant);
 
         t.end();
     });

--- a/test/test.js
+++ b/test/test.js
@@ -100,9 +100,9 @@ test('property', function(t) {
             property: 'mapbox'
         });
 
-        t.equal(scale({mapbox: 1, google: 0}), 2);
-        t.equal(scale({mapbox: 2, google: 0}), 4);
-        t.equal(scale({mapbox: 3, google: 0}), 6);
+        t.equal(scale(0, {mapbox: 1, google: 0}), 2);
+        t.equal(scale(0, {mapbox: 2, google: 0}), 4);
+        t.equal(scale(0, {mapbox: 3, google: 0}), 6);
 
         t.end();
     });
@@ -114,9 +114,9 @@ test('property', function(t) {
             property: '$zoom'
         });
 
-        t.equal(scale({'$zoom': 1}), 2);
-        t.equal(scale({'$zoom': 2}), 4);
-        t.equal(scale({'$zoom': 3}), 6);
+        t.equal(scale(1, {mapbox: 0}), 2);
+        t.equal(scale(2, {mapbox: 0}), 4);
+        t.equal(scale(3, {mapbox: 0}), 6);
 
         t.end();
     });

--- a/test/test.js
+++ b/test/test.js
@@ -264,3 +264,47 @@ test('domain types', function(t) {
 
     t.end();
 });
+
+test('range types', function(t) {
+
+    t.test('number', function(t) {
+        var scale = MapboxGLScale({
+            domain: [1, 3],
+            range: [2, 6],
+            property: 'mapbox'
+        });
+
+        t.equal(scale({mapbox: 1})({}), 2);
+        t.equal(scale({mapbox: 3})({}), 6);
+
+        t.end();
+    });
+
+    t.test('string', function(t) {
+        var scale = MapboxGLScale({
+            domain: [1, 3],
+            range: ['a', 'c'],
+            property: 'mapbox'
+        });
+
+        t.equal(scale({mapbox: 1})({}), 'a');
+        t.equal(scale({mapbox: 3})({}), 'c');
+
+        t.end();
+    });
+
+    t.test('boolean', function(t) {
+        var scale = MapboxGLScale({
+            domain: [1, 3],
+            range: [true, false],
+            property: 'mapbox'
+        });
+
+        t.equal(scale({mapbox: 1})({}), true);
+        t.equal(scale({mapbox: 3})({}), false);
+
+        t.end();
+    });
+
+    t.end();
+});

--- a/test/test.js
+++ b/test/test.js
@@ -3,7 +3,7 @@
 var test = require('tape');
 var MapboxGLScale = require('../');
 
-test('constant', function(t) {
+test('constant type', function(t) {
     t.test('array', function(t) {
         var scale = MapboxGLScale([1]);
 
@@ -27,137 +27,43 @@ test('constant', function(t) {
     t.end();
 });
 
-test('domain & range', function(t) {
-    t.test('one element', function(t) {
-        var scale = MapboxGLScale({
-            domain: [1],
-            range: [2]
-        });
-
-        t.equal(scale({'$zoom': 0})({}), 2);
-        t.equal(scale({'$zoom': 1})({}), 2);
-        t.equal(scale({'$zoom': 2})({}), 2);
-
-        t.end();
-    });
-
-    t.test('two elements', function(t) {
-        var scale = MapboxGLScale({
-            domain: [1, 3],
-            range: [2, 6]
-        });
-
-        t.equal(scale({'$zoom': 0})({}), 2);
-        t.equal(scale({'$zoom': 1})({}), 2);
-        t.equal(scale({'$zoom': 2})({}), 4);
-        t.equal(scale({'$zoom': 3})({}), 6);
-        t.equal(scale({'$zoom': 4})({}), 6);
-
-        t.end();
-    });
-
-    t.test('three elements', function(t) {
-        var scale = MapboxGLScale({
-            domain: [1, 3, 5],
-            range: [2, 6, 10]
-        });
-
-        t.equal(scale({'$zoom': 0})({}), 2);
-        t.equal(scale({'$zoom': 1})({}), 2);
-        t.equal(scale({'$zoom': 2})({}), 4);
-        t.equal(scale({'$zoom': 3})({}), 6);
-        t.equal(scale({'$zoom': 4})({}), 8);
-        t.equal(scale({'$zoom': 5})({}), 10);
-        t.equal(scale({'$zoom': 6})({}), 10);
-
-        t.end();
-    });
-
-});
-
-test('base', function(t) {
-    var scale = MapboxGLScale({
-        domain: [1, 3],
-        range: [2, 6],
-        base: 2
-    });
-
-    t.equal(scale({'$zoom': 0})({}), 2);
-    t.equal(scale({'$zoom': 1})({}), 2);
-    t.equal(scale({'$zoom': 2})({}), 30 / 9);
-    t.equal(scale({'$zoom': 3})({}), 6);
-    t.equal(scale({'$zoom': 4})({}), 6);
-
-    t.end();
-});
-
-test('global / feature attributes', function(t) {
-
-    t.test('global', function(t) {
-        var scale = MapboxGLScale({
-            domain: [1, 3],
-            range: [2, 6],
-            property: 'mapbox'
-        });
-
-        t.equal(scale({mapbox: 2})({}), 4);
-
-        t.end();
-    });
-
-    t.test('feature', function(t) {
-        var scale = MapboxGLScale({
-            domain: [1, 3],
-            range: [2, 6],
-            property: 'mapbox'
-        });
-
-        t.equal(scale({})({mapbox: 2}), 4);
-
-        t.end();
-    });
-
-    t.end();
-});
-
 test('property', function(t) {
 
     t.test('missing property', function(t) {
         var scale = MapboxGLScale({
-            domain: [1, 3],
-            range: [2, 6],
+            type: 'ordinal',
+            domain: ['map', 'box'],
+            range: ['neat', 'swell'],
             property: 'mapbox'
         });
 
-        t.equal(scale({})({}), 2);
+        t.equal(scale({})({}), 'neat');
 
         t.end();
     });
 
-    t.test('one property', function(t) {
+    t.test('global property', function(t) {
         var scale = MapboxGLScale({
-            domain: [1, 3],
-            range: [2, 6],
+            type: 'ordinal',
+            domain: ['map', 'box'],
+            range: ['neat', 'swell'],
             property: 'mapbox'
         });
 
-        t.equal(scale({mapbox: 1})({}), 2);
-        t.equal(scale({mapbox: 2})({}), 4);
-        t.equal(scale({mapbox: 3})({}), 6);
+        t.equal(scale({mapbox: 'box'})({}), 'swell');
 
         t.end();
     });
 
-    t.test('two properties', function(t) {
+    t.test('feature property', function(t) {
         var scale = MapboxGLScale({
-            domain: [1, 3],
-            range: [2, 6],
+            type: 'ordinal',
+            domain: ['map', 'box'],
+            range: ['neat', 'swell'],
             property: 'mapbox'
         });
 
-        t.equal(scale({mapbox: 1, google: 3})({}), 2);
-        t.equal(scale({mapbox: 2, google: 3})({}), 4);
-        t.equal(scale({mapbox: 3, google: 0})({}), 6);
+        t.equal(scale({})({mapbox: 'box'}), 'swell');
 
         t.end();
     });
@@ -165,146 +71,221 @@ test('property', function(t) {
     t.end();
 });
 
-test('attribute arguments', function(t) {
+test('ordinal type', function(t) {
 
-    t.test('object, object', function(t) {
-        var scale = MapboxGLScale({
-            domain: [1, 3],
-            range: [2, 6],
-            property: 'mapbox'
+    t.test('domain & range', function(t) {
+
+        t.test('one element', function(t) {
+            var scale = MapboxGLScale({
+                type: 'ordinal',
+                domain: ['umpteen'],
+                range: [42],
+                property: 'mapbox'
+            });
+
+            t.equal(scale({'mapbox': 'umpteen'})({}), 42);
+            t.equal(scale({'mapbox': 'derp'})({}), 42);
+
+            t.end();
         });
 
-        t.equal(scale({mapbox: 1}, {mapbox: 3})({}), 2);
-        t.equal(scale({google: 3}, {mapbox: 1})({}), 2);
+        t.test('two elements', function(t) {
+            var scale = MapboxGLScale({
+                type: 'ordinal',
+                domain: ['umpteen', 'eleventy'],
+                range: [42, 110],
+                property: 'mapbox'
+            });
+
+            t.equal(scale({'mapbox': 'umpteen'})({}), 42);
+            t.equal(scale({'mapbox': 'eleventy'})({}), 110);
+
+            t.end();
+        });
+
+        t.test('three elements', function(t) {
+            var scale = MapboxGLScale({
+                type: 'ordinal',
+                domain: ['umpteen', 'eleventy', 'bunch'],
+                range: [42, 110, 17],
+                property: 'mapbox'
+            });
+
+            t.equal(scale({'mapbox': 'umpteen'})({}), 42);
+            t.equal(scale({'mapbox': 'eleventy'})({}), 110);
+            t.equal(scale({'mapbox': 'bunch'})({}), 17);
+
+            t.end();
+        });
+
+    });
+
+    t.test('range types', function(t) {
+
+        t.test('number', function(t) {
+            var scale = MapboxGLScale({
+                type: 'ordinal',
+                domain: [1, 3],
+                range: [2, 6],
+                property: 'mapbox'
+            });
+
+            t.equal(scale({mapbox: 1})({}), 2);
+            t.equal(scale({mapbox: 3})({}), 6);
+
+            t.end();
+        });
+
+        t.test('string', function(t) {
+            var scale = MapboxGLScale({
+                type: 'ordinal',
+                domain: [1, 3],
+                range: ['a', 'c'],
+                property: 'mapbox'
+            });
+
+            t.equal(scale({mapbox: 1})({}), 'a');
+            t.equal(scale({mapbox: 3})({}), 'c');
+
+            t.end();
+        });
+
+        t.test('boolean', function(t) {
+            var scale = MapboxGLScale({
+                type: 'ordinal',
+                domain: [1, 3],
+                range: [true, false],
+                property: 'mapbox'
+            });
+
+            t.equal(scale({mapbox: 1})({}), true);
+            t.equal(scale({mapbox: 3})({}), false);
+
+            t.end();
+        });
 
         t.end();
     });
 
+    t.test('domain types', function(t) {
+
+        t.test('number', function(t) {
+            var scale = MapboxGLScale({
+                type: 'ordinal',
+                domain: [1, 3],
+                range: [2, 6],
+                property: 'mapbox'
+            });
+
+            t.equal(scale({mapbox: 1})({}), 2);
+            t.equal(scale({mapbox: 3})({}), 6);
+
+            t.end();
+        });
+
+        t.test('string', function(t) {
+            var scale = MapboxGLScale({
+                type: 'ordinal',
+                domain: ['a', 'c'],
+                range: [2, 6],
+                property: 'mapbox'
+            });
+
+            t.equal(scale({mapbox: 'a'})({}), 2);
+            t.equal(scale({mapbox: 'c'})({}), 6);
+
+            t.end();
+        });
+
+        t.test('boolean', function(t) {
+            var scale = MapboxGLScale({
+                type: 'ordinal',
+                domain: [true, false],
+                range: [2, 6],
+                property: 'mapbox'
+            });
+
+            t.equal(scale({mapbox: true})({}), 2);
+            t.equal(scale({mapbox: false})({}), 6);
+
+            t.end();
+        });
+
+        t.end();
+    });
+
+
 });
 
-test('rounding', function(t) {
+test('power type', function(t) {
 
-    t.test('none', function(t) {
+    t.test('base', function(t) {
         var scale = MapboxGLScale({
+            type: 'power',
             domain: [1, 3],
             range: [2, 6],
-            rounding: 'none'
+            base: 2
         });
 
         t.equal(scale({'$zoom': 0})({}), 2);
         t.equal(scale({'$zoom': 1})({}), 2);
-        t.equal(scale({'$zoom': 1.9})({}), 1.9 * 2);
-        t.equal(scale({'$zoom': 2})({}), 4);
-        t.equal(scale({'$zoom': 2.1})({}), 2.1 * 2);
+        t.equal(scale({'$zoom': 2})({}), 30 / 9);
         t.equal(scale({'$zoom': 3})({}), 6);
         t.equal(scale({'$zoom': 4})({}), 6);
 
         t.end();
     });
 
-    t.test('floor', function(t) {
-        var scale = MapboxGLScale({
-            domain: [1, 3],
-            range: [2, 6],
-            rounding: 'floor'
+
+    t.test('domain & range', function(t) {
+        t.test('one element', function(t) {
+            var scale = MapboxGLScale({
+                type: 'power',
+                domain: [1],
+                range: [2]
+            });
+
+            t.equal(scale({'$zoom': 0})({}), 2);
+            t.equal(scale({'$zoom': 1})({}), 2);
+            t.equal(scale({'$zoom': 2})({}), 2);
+
+            t.end();
         });
 
-        t.equal(scale({'$zoom': 0})({}), 2);
-        t.equal(scale({'$zoom': 1})({}), 2);
-        t.equal(scale({'$zoom': 2})({}), 2);
-        t.equal(scale({'$zoom': 3})({}), 6);
-        t.equal(scale({'$zoom': 4})({}), 6);
+        t.test('two elements', function(t) {
+            var scale = MapboxGLScale({
+                type: 'power',
+                domain: [1, 3],
+                range: [2, 6]
+            });
 
-        t.end();
-    });
+            t.equal(scale({'$zoom': 0})({}), 2);
+            t.equal(scale({'$zoom': 1})({}), 2);
+            t.equal(scale({'$zoom': 2})({}), 4);
+            t.equal(scale({'$zoom': 3})({}), 6);
+            t.equal(scale({'$zoom': 4})({}), 6);
 
-    t.end();
-});
-
-test('domain types', function(t) {
-
-    t.test('number', function(t) {
-        var scale = MapboxGLScale({
-            domain: [1, 3],
-            range: [2, 6],
-            property: 'mapbox'
+            t.end();
         });
 
-        t.equal(scale({mapbox: 1})({}), 2);
-        t.equal(scale({mapbox: 3})({}), 6);
+        t.test('three elements', function(t) {
+            var scale = MapboxGLScale({
+                type: 'power',
+                domain: [1, 3, 5],
+                range: [2, 6, 10]
+            });
 
-        t.end();
-    });
+            t.equal(scale({'$zoom': 0})({}), 2);
+            t.equal(scale({'$zoom': 1})({}), 2);
+            t.equal(scale({'$zoom': 2})({}), 4);
+            t.equal(scale({'$zoom': 3})({}), 6);
+            t.equal(scale({'$zoom': 4})({}), 8);
+            t.equal(scale({'$zoom': 5})({}), 10);
+            t.equal(scale({'$zoom': 6})({}), 10);
 
-    t.test('string', function(t) {
-        var scale = MapboxGLScale({
-            domain: ['a', 'c'],
-            range: [2, 6],
-            property: 'mapbox'
+            t.end();
         });
 
-        t.equal(scale({mapbox: 'a'})({}), 2);
-        t.equal(scale({mapbox: 'c'})({}), 6);
-
-        t.end();
     });
 
-    t.test('boolean', function(t) {
-        var scale = MapboxGLScale({
-            domain: [true, false],
-            range: [2, 6],
-            property: 'mapbox'
-        });
-
-        t.equal(scale({mapbox: true})({}), 2);
-        t.equal(scale({mapbox: false})({}), 6);
-
-        t.end();
-    });
-
-    t.end();
-});
-
-test('range types', function(t) {
-
-    t.test('number', function(t) {
-        var scale = MapboxGLScale({
-            domain: [1, 3],
-            range: [2, 6],
-            property: 'mapbox'
-        });
-
-        t.equal(scale({mapbox: 1})({}), 2);
-        t.equal(scale({mapbox: 3})({}), 6);
-
-        t.end();
-    });
-
-    t.test('string', function(t) {
-        var scale = MapboxGLScale({
-            domain: [1, 3],
-            range: ['a', 'c'],
-            property: 'mapbox'
-        });
-
-        t.equal(scale({mapbox: 1})({}), 'a');
-        t.equal(scale({mapbox: 3})({}), 'c');
-
-        t.end();
-    });
-
-    t.test('boolean', function(t) {
-        var scale = MapboxGLScale({
-            domain: [1, 3],
-            range: [true, false],
-            property: 'mapbox'
-        });
-
-        t.equal(scale({mapbox: 1})({}), true);
-        t.equal(scale({mapbox: 3})({}), false);
-
-        t.end();
-    });
-
-    t.end();
 });

--- a/test/test.js
+++ b/test/test.js
@@ -3,29 +3,241 @@
 var test = require('tape');
 var MapboxGLScale = require('../');
 
-test('constant type', function(t) {
-    t.test('array', function(t) {
-        var scale = MapboxGLScale([1]);
+test('scale types', function(t) {
 
-        t.deepEqual(scale({'$zoom': 0})({}), [1]);
-        t.deepEqual(scale({'$zoom': 1})({}), [1]);
-        t.deepEqual(scale({'$zoom': 2})({}), [1]);
+    t.test('contant', function(t) {
 
+        t.test('range types', function(t) {
+
+            t.test('array', function(t) {
+                var scale = MapboxGLScale([1]);
+
+                t.deepEqual(scale({'$zoom': 0})({}), [1]);
+                t.deepEqual(scale({'$zoom': 1})({}), [1]);
+                t.deepEqual(scale({'$zoom': 2})({}), [1]);
+
+                t.end();
+            });
+
+            t.test('number', function(t) {
+                var scale = MapboxGLScale(1);
+
+                t.equal(scale({'$zoom': 0})({}), 1);
+                t.equal(scale({'$zoom': 1})({}), 1);
+                t.equal(scale({'$zoom': 2})({}), 1);
+
+                t.end();
+            });
+
+            t.test('string', function(t) {
+                var scale = MapboxGLScale('mapbox');
+
+                t.equal(scale({'$zoom': 0})({}), 'mapbox');
+                t.equal(scale({'$zoom': 1})({}), 'mapbox');
+                t.equal(scale({'$zoom': 2})({}), 'mapbox');
+
+                t.end();
+            });
+
+        });
+
+    });
+
+    t.test('interval', function(t) {
+        // TODO @nocommit
         t.end();
     });
 
-    t.test('number', function(t) {
-        var scale = MapboxGLScale(1);
+    t.test('exponential', function(t) {
 
-        t.equal(scale({'$zoom': 0})({}), 1);
-        t.equal(scale({'$zoom': 1})({}), 1);
-        t.equal(scale({'$zoom': 2})({}), 1);
+        t.test('base', function(t) {
+            var scale = MapboxGLScale({
+                type: 'exponential',
+                domain: [1, 3],
+                range: [2, 6],
+                base: 2
+            });
 
-        t.end();
+            t.equal(scale({'$zoom': 0})({}), 2);
+            t.equal(scale({'$zoom': 1})({}), 2);
+            t.equal(scale({'$zoom': 2})({}), 30 / 9);
+            t.equal(scale({'$zoom': 3})({}), 6);
+            t.equal(scale({'$zoom': 4})({}), 6);
+
+            t.end();
+        });
+
+        t.test('domain & range', function(t) {
+            t.test('one element', function(t) {
+                var scale = MapboxGLScale({
+                    type: 'exponential',
+                    domain: [1],
+                    range: [2]
+                });
+
+                t.equal(scale({'$zoom': 0})({}), 2);
+                t.equal(scale({'$zoom': 1})({}), 2);
+                t.equal(scale({'$zoom': 2})({}), 2);
+
+                t.end();
+            });
+
+            t.test('two elements', function(t) {
+                var scale = MapboxGLScale({
+                    type: 'exponential',
+                    domain: [1, 3],
+                    range: [2, 6]
+                });
+
+                t.equal(scale({'$zoom': 0})({}), 2);
+                t.equal(scale({'$zoom': 1})({}), 2);
+                t.equal(scale({'$zoom': 2})({}), 4);
+                t.equal(scale({'$zoom': 3})({}), 6);
+                t.equal(scale({'$zoom': 4})({}), 6);
+
+                t.end();
+            });
+
+            t.test('three elements', function(t) {
+                var scale = MapboxGLScale({
+                    type: 'exponential',
+                    domain: [1, 3, 5],
+                    range: [2, 6, 10]
+                });
+
+                t.equal(scale({'$zoom': 0})({}), 2);
+                t.equal(scale({'$zoom': 1})({}), 2);
+                t.equal(scale({'$zoom': 2})({}), 4);
+                t.equal(scale({'$zoom': 3})({}), 6);
+                t.equal(scale({'$zoom': 4})({}), 8);
+                t.equal(scale({'$zoom': 5})({}), 10);
+                t.equal(scale({'$zoom': 6})({}), 10);
+
+                t.end();
+            });
+
+        });
+
     });
+
+    t.test('categorical', function(t) {
+
+        t.test('one element', function(t) {
+            var scale = MapboxGLScale({
+                type: 'categorical',
+                domain: ['umpteen'],
+                range: [42],
+                property: 'mapbox'
+            });
+
+            t.equal(scale({})({mapbox: 'umpteen'}), 42);
+            t.equal(scale({})({mapbox: 'derp'}), 42);
+
+            t.end();
+        });
+
+        t.test('two elements', function(t) {
+            var scale = MapboxGLScale({
+                type: 'categorical',
+                domain: ['umpteen', 'eleventy'],
+                range: [42, 110],
+                property: 'mapbox'
+            });
+
+            t.equal(scale({})({mapbox: 'umpteen'}), 42);
+            t.equal(scale({})({mapbox: 'eleventy'}), 110);
+            t.equal(scale({})({mapbox: 'derp'}), 42);
+
+
+            t.end();
+        });
+
+    });
+
+    t.test('interval', function(t) {
+
+        t.test('one domain element', function(t) {
+            var scale = MapboxGLScale({
+                type: 'interval',
+                domain: [0],
+                range: [11, 111],
+                property: 'mapbox'
+            });
+
+            t.equal(scale({})({mapbox: -0.5}), 11);
+            t.equal(scale({})({mapbox: 0}), 111);
+            t.equal(scale({})({mapbox: 0.5}), 111);
+
+            t.end();
+        });
+
+        t.test('two domain elements', function(t) {
+            var scale = MapboxGLScale({
+                type: 'interval',
+                domain: [0, 1],
+                range: [11, 111, 1111],
+                property: 'mapbox'
+            });
+
+            t.equal(scale({})({mapbox: -0.5}), 11);
+            t.equal(scale({})({mapbox: 0}), 111);
+            t.equal(scale({})({mapbox: 0.5}), 111);
+            t.equal(scale({})({mapbox: 1}), 1111);
+            t.equal(scale({})({mapbox: 1.5}), 1111);
+
+            t.end();
+        });
+
+    });
+
 });
 
-test('scale isConstant', function(t) {
+test('property', function(t) {
+
+    t.test('missing property', function(t) {
+        var scale = MapboxGLScale({
+            type: 'categorical',
+            domain: ['map', 'box'],
+            range: ['neat', 'swell'],
+            property: 'mapbox'
+        });
+
+        t.equal(scale({})({}), 'neat');
+
+        t.end();
+    });
+
+    t.test('global property', function(t) {
+        var scale = MapboxGLScale({
+            type: 'categorical',
+            domain: ['map', 'box'],
+            range: ['neat', 'swell'],
+            property: 'mapbox'
+        });
+
+        t.equal(scale({})({mapbox: 'box'}), 'swell');
+
+        t.end();
+    });
+
+    t.test('feature property', function(t) {
+        var scale = MapboxGLScale({
+            type: 'categorical',
+            domain: ['map', 'box'],
+            range: ['neat', 'swell'],
+            property: 'mapbox'
+        });
+
+        t.equal(scale({})({mapbox: 'box'}), 'swell');
+
+        t.end();
+    });
+
+    t.end();
+});
+
+test('isConstant', function(t) {
+
     t.test('constant', function(t) {
         var scale = MapboxGLScale(1);
 
@@ -80,315 +292,5 @@ test('scale isConstant', function(t) {
     });
 
     t.end();
-});
-
-test('property', function(t) {
-
-    t.test('missing property', function(t) {
-        var scale = MapboxGLScale({
-            type: 'ordinal',
-            domain: ['map', 'box'],
-            range: ['neat', 'swell'],
-            property: 'mapbox'
-        });
-
-        t.equal(scale({})({}), 'neat');
-
-        t.end();
-    });
-
-    t.test('global property', function(t) {
-        var scale = MapboxGLScale({
-            type: 'ordinal',
-            domain: ['map', 'box'],
-            range: ['neat', 'swell'],
-            property: 'mapbox'
-        });
-
-        t.equal(scale({})({mapbox: 'box'}), 'swell');
-
-        t.end();
-    });
-
-    t.test('feature property', function(t) {
-        var scale = MapboxGLScale({
-            type: 'ordinal',
-            domain: ['map', 'box'],
-            range: ['neat', 'swell'],
-            property: 'mapbox'
-        });
-
-        t.equal(scale({})({mapbox: 'box'}), 'swell');
-
-        t.end();
-    });
-
-    t.end();
-});
-
-test('ordinal type', function(t) {
-
-    t.test('domain & range', function(t) {
-
-        t.test('one element', function(t) {
-            var scale = MapboxGLScale({
-                type: 'ordinal',
-                domain: ['umpteen'],
-                range: [42],
-                property: 'mapbox'
-            });
-
-            t.equal(scale({})({mapbox: 'umpteen'}), 42);
-            t.equal(scale({})({mapbox: 'derp'}), 42);
-
-            t.end();
-        });
-
-        t.test('two elements', function(t) {
-            var scale = MapboxGLScale({
-                type: 'ordinal',
-                domain: ['umpteen', 'eleventy'],
-                range: [42, 110],
-                property: 'mapbox'
-            });
-
-            t.equal(scale({})({mapbox: 'umpteen'}), 42);
-            t.equal(scale({})({mapbox: 'eleventy'}), 110);
-
-            t.end();
-        });
-
-        t.test('three elements', function(t) {
-            var scale = MapboxGLScale({
-                type: 'ordinal',
-                domain: ['umpteen', 'eleventy', 'bunch'],
-                range: [42, 110, 17],
-                property: 'mapbox'
-            });
-
-            t.equal(scale({})({mapbox: 'umpteen'}), 42);
-            t.equal(scale({})({mapbox: 'eleventy'}), 110);
-            t.equal(scale({})({mapbox: 'bunch'}), 17);
-
-            t.end();
-        });
-
-    });
-
-    t.test('range types', function(t) {
-
-        t.test('number', function(t) {
-            var scale = MapboxGLScale({
-                type: 'ordinal',
-                domain: [1, 3],
-                range: [2, 6],
-                property: 'mapbox'
-            });
-
-            t.equal(scale({})({mapbox: 1}), 2);
-            t.equal(scale({})({mapbox: 3}), 6);
-
-            t.end();
-        });
-
-        t.test('string', function(t) {
-            var scale = MapboxGLScale({
-                type: 'ordinal',
-                domain: [1, 3],
-                range: ['a', 'c'],
-                property: 'mapbox'
-            });
-
-            t.equal(scale({})({mapbox: 1}), 'a');
-            t.equal(scale({})({mapbox: 3}), 'c');
-
-            t.end();
-        });
-
-        t.test('boolean', function(t) {
-            var scale = MapboxGLScale({
-                type: 'ordinal',
-                domain: [1, 3],
-                range: [true, false],
-                property: 'mapbox'
-            });
-
-            t.equal(scale({})({mapbox: 1}), true);
-            t.equal(scale({})({mapbox: 3}), false);
-
-            t.end();
-        });
-
-        t.end();
-    });
-
-    t.test('domain types', function(t) {
-
-        t.test('number', function(t) {
-            var scale = MapboxGLScale({
-                type: 'ordinal',
-                domain: [1, 3],
-                range: [2, 6],
-                property: 'mapbox'
-            });
-
-            t.equal(scale({})({mapbox: 1}), 2);
-            t.equal(scale({})({mapbox: 3}), 6);
-
-            t.end();
-        });
-
-        t.test('string', function(t) {
-            var scale = MapboxGLScale({
-                type: 'ordinal',
-                domain: ['a', 'c'],
-                range: [2, 6],
-                property: 'mapbox'
-            });
-
-            t.equal(scale({})({mapbox: 'a'}), 2);
-            t.equal(scale({})({mapbox: 'c'}), 6);
-
-            t.end();
-        });
-
-        t.test('boolean', function(t) {
-            var scale = MapboxGLScale({
-                type: 'ordinal',
-                domain: [true, false],
-                range: [2, 6],
-                property: 'mapbox'
-            });
-
-            t.equal(scale({})({mapbox: true}), 2);
-            t.equal(scale({})({mapbox: false}), 6);
-
-            t.end();
-        });
-
-        t.end();
-    });
-
-
-});
-
-test('power type', function(t) {
-
-    t.test('base', function(t) {
-        var scale = MapboxGLScale({
-            type: 'power',
-            domain: [1, 3],
-            range: [2, 6],
-            base: 2
-        });
-
-        t.equal(scale({'$zoom': 0})({}), 2);
-        t.equal(scale({'$zoom': 1})({}), 2);
-        t.equal(scale({'$zoom': 2})({}), 30 / 9);
-        t.equal(scale({'$zoom': 3})({}), 6);
-        t.equal(scale({'$zoom': 4})({}), 6);
-
-        t.end();
-    });
-
-    t.test('domain & range', function(t) {
-        t.test('one element', function(t) {
-            var scale = MapboxGLScale({
-                type: 'power',
-                domain: [1],
-                range: [2]
-            });
-
-            t.equal(scale({'$zoom': 0})({}), 2);
-            t.equal(scale({'$zoom': 1})({}), 2);
-            t.equal(scale({'$zoom': 2})({}), 2);
-
-            t.end();
-        });
-
-        t.test('two elements', function(t) {
-            var scale = MapboxGLScale({
-                type: 'power',
-                domain: [1, 3],
-                range: [2, 6]
-            });
-
-            t.equal(scale({'$zoom': 0})({}), 2);
-            t.equal(scale({'$zoom': 1})({}), 2);
-            t.equal(scale({'$zoom': 2})({}), 4);
-            t.equal(scale({'$zoom': 3})({}), 6);
-            t.equal(scale({'$zoom': 4})({}), 6);
-
-            t.end();
-        });
-
-        t.test('three elements', function(t) {
-            var scale = MapboxGLScale({
-                type: 'power',
-                domain: [1, 3, 5],
-                range: [2, 6, 10]
-            });
-
-            t.equal(scale({'$zoom': 0})({}), 2);
-            t.equal(scale({'$zoom': 1})({}), 2);
-            t.equal(scale({'$zoom': 2})({}), 4);
-            t.equal(scale({'$zoom': 3})({}), 6);
-            t.equal(scale({'$zoom': 4})({}), 8);
-            t.equal(scale({'$zoom': 5})({}), 10);
-            t.equal(scale({'$zoom': 6})({}), 10);
-
-            t.end();
-        });
-
-    });
-
-    t.test('range types', function(t) {
-
-        t.test('number', function(t) {
-            var scale = MapboxGLScale({
-                type: 'power',
-                domain: [1, 3],
-                range: [2, 6],
-                property: 'mapbox'
-            });
-
-            t.equal(scale({})({mapbox: 1}), 2);
-            t.equal(scale({})({mapbox: 3}), 6);
-
-            t.end();
-        });
-
-        t.test('string', function(t) {
-            var scale = MapboxGLScale({
-                type: 'power',
-                domain: [1, 3],
-                range: ['a', 'c'],
-                rounding: 'floor',
-                property: 'mapbox'
-            });
-
-            t.equal(scale({})({mapbox: 1}), 'a');
-            t.equal(scale({})({mapbox: 3}), 'c');
-
-            t.end();
-        });
-
-        t.test('boolean', function(t) {
-            var scale = MapboxGLScale({
-                type: 'power',
-                domain: [1, 3],
-                range: [true, false],
-                rounding: 'floor',
-                property: 'mapbox'
-            });
-
-            t.equal(scale({})({mapbox: 1}), true);
-            t.equal(scale({})({mapbox: 3}), false);
-
-            t.end();
-        });
-
-        t.end();
-    });
 
 });

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,183 @@
+'use strict';
+
+var test = require('tape');
+var MapboxGLScale = require('../');
+
+test('constant', function(t) {
+    t.test('array', function(t) {
+        var scale = MapboxGLScale([1]);
+
+        t.deepEqual(scale(0), [1]);
+        t.deepEqual(scale(1), [1]);
+        t.deepEqual(scale(2), [1]);
+
+        t.end();
+    });
+
+    t.test('number', function(t) {
+        var scale = MapboxGLScale(1);
+
+        t.equal(scale(0), 1);
+        t.equal(scale(1), 1);
+        t.equal(scale(2), 1);
+
+        t.end();
+    });
+
+    t.end();
+});
+
+test('domain & range', function(t) {
+    t.test('one element', function(t) {
+        var scale = MapboxGLScale({
+            domain: [1],
+            range: [2]
+        });
+
+        t.equal(scale(0), 2);
+        t.equal(scale(1), 2);
+        t.equal(scale(2), 2);
+
+        t.end();
+    });
+
+    t.test('two elements', function(t) {
+        var scale = MapboxGLScale({
+            domain: [1, 3],
+            range: [2, 6]
+        });
+
+        t.equal(scale(0), 2);
+        t.equal(scale(1), 2);
+        t.equal(scale(2), 4);
+        t.equal(scale(3), 6);
+        t.equal(scale(4), 6);
+
+        t.end();
+    });
+
+    t.test('three elements', function(t) {
+        var scale = MapboxGLScale({
+            domain: [1, 3, 5],
+            range: [2, 6, 10]
+        });
+
+        t.equal(scale(0), 2);
+        t.equal(scale(1), 2);
+        t.equal(scale(2), 4);
+        t.equal(scale(3), 6);
+        t.equal(scale(4), 8);
+        t.equal(scale(5), 10);
+        t.equal(scale(6), 10);
+
+        t.end();
+    });
+
+});
+
+test('base', function(t) {
+    var scale = MapboxGLScale({
+        domain: [1, 3],
+        range: [2, 6],
+        base: 2
+    });
+
+    t.equal(scale(0), 2);
+    t.equal(scale(1), 2);
+    t.equal(scale(2), 30 / 9);
+    t.equal(scale(3), 6);
+    t.equal(scale(4), 6);
+
+    t.end();
+});
+
+test('property', function(t) {
+
+    t.test('two properties', function(t) {
+        var scale = MapboxGLScale({
+            domain: [1, 3],
+            range: [2, 6],
+            property: 'mapbox'
+        });
+
+        t.equal(scale({mapbox: 1, google: 0}), 2);
+        t.equal(scale({mapbox: 2, google: 0}), 4);
+        t.equal(scale({mapbox: 3, google: 0}), 6);
+
+        t.end();
+    });
+
+    t.test('$zoom', function(t) {
+        var scale = MapboxGLScale({
+            domain: [1, 3],
+            range: [2, 6],
+            property: '$zoom'
+        });
+
+        t.equal(scale({'$zoom': 1}), 2);
+        t.equal(scale({'$zoom': 2}), 4);
+        t.equal(scale({'$zoom': 3}), 6);
+
+        t.end();
+    });
+
+    t.end();
+});
+
+
+test('rounding', function(t) {
+
+    t.test('none', function(t) {
+        var scale = MapboxGLScale({
+            domain: [1, 3],
+            range: [2, 6],
+            rounding: 'none'
+        });
+
+        t.equal(scale(0), 2);
+        t.equal(scale(1), 2);
+        t.equal(scale(1.9), 1.9 * 2);
+        t.equal(scale(2), 4);
+        t.equal(scale(2.1), 2.1 * 2);
+        t.equal(scale(3), 6);
+        t.equal(scale(4), 6);
+
+        t.end();
+    });
+
+    t.test('floor', function(t) {
+        var scale = MapboxGLScale({
+            domain: [1, 3],
+            range: [2, 6],
+            rounding: 'floor'
+        });
+
+        t.equal(scale(0), 2);
+        t.equal(scale(1), 2);
+        t.equal(scale(2), 2);
+        t.equal(scale(3), 6);
+        t.equal(scale(4), 6);
+
+        t.end();
+    });
+
+    t.test('ceiling', function(t) {
+        var scale = MapboxGLScale({
+            domain: [1, 3],
+            range: [2, 6],
+            rounding: 'ceiling'
+        });
+
+        t.equal(scale(0), 2);
+        t.equal(scale(1), 2);
+        t.equal(scale(2), 6);
+        t.equal(scale(3), 6);
+        t.equal(scale(4), 6);
+
+        t.end();
+    });
+
+    t.end();
+
+});
+

--- a/test/test.js
+++ b/test/test.js
@@ -93,6 +93,32 @@ test('base', function(t) {
 
 test('property', function(t) {
 
+    t.test('missing property', function(t) {
+        var scale = MapboxGLScale({
+            domain: [1, 3],
+            range: [2, 6],
+            property: 'mapbox'
+        });
+
+        t.equal(scale({}), 2);
+
+        t.end();
+    });
+
+    t.test('one property', function(t) {
+        var scale = MapboxGLScale({
+            domain: [1, 3],
+            range: [2, 6],
+            property: 'mapbox'
+        });
+
+        t.equal(scale({mapbox: 1}), 2);
+        t.equal(scale({mapbox: 2}), 4);
+        t.equal(scale({mapbox: 3}), 6);
+
+        t.end();
+    });
+
     t.test('two properties', function(t) {
         var scale = MapboxGLScale({
             domain: [1, 3],
@@ -100,23 +126,37 @@ test('property', function(t) {
             property: 'mapbox'
         });
 
-        t.equal(scale(0, {mapbox: 1, google: 0}), 2);
-        t.equal(scale(0, {mapbox: 2, google: 0}), 4);
-        t.equal(scale(0, {mapbox: 3, google: 0}), 6);
+        t.equal(scale({mapbox: 1, google: 3}), 2);
+        t.equal(scale({mapbox: 2, google: 3}), 4);
+        t.equal(scale({mapbox: 3, google: 0}), 6);
 
         t.end();
     });
 
-    t.test('$zoom', function(t) {
+    t.test('$zoom from number', function(t) {
         var scale = MapboxGLScale({
             domain: [1, 3],
             range: [2, 6],
             property: '$zoom'
         });
 
-        t.equal(scale(1, {mapbox: 0}), 2);
-        t.equal(scale(2, {mapbox: 0}), 4);
-        t.equal(scale(3, {mapbox: 0}), 6);
+        t.equal(scale(1), 2);
+        t.equal(scale(2), 4);
+        t.equal(scale(3), 6);
+
+        t.end();
+    });
+
+    t.test('$zoom from object', function(t) {
+        var scale = MapboxGLScale({
+            domain: [1, 3],
+            range: [2, 6],
+            property: '$zoom'
+        });
+
+        t.equal(scale({'$zoom': 1}), 2);
+        t.equal(scale({'$zoom': 2}), 4);
+        t.equal(scale({'$zoom': 3}), 6);
 
         t.end();
     });
@@ -124,6 +164,46 @@ test('property', function(t) {
     t.end();
 });
 
+test('attribute arguments', function(t) {
+
+    t.test('object, object', function(t) {
+        var scale = MapboxGLScale({
+            domain: [1, 3],
+            range: [2, 6],
+            property: 'mapbox'
+        });
+
+        t.equal(scale({mapbox: 1}, {google: 3}), 2);
+        t.equal(scale({google: 3}, {mapbox: 1}), 2);
+
+        t.end();
+    });
+
+    t.test('object, number', function(t) {
+        var scale = MapboxGLScale({
+            domain: [1, 3],
+            range: [2, 6],
+            property: 'mapbox'
+        });
+
+        t.equal(scale(3, {mapbox: 1}), 2);
+
+        t.end();
+    });
+
+    t.test('object, number', function(t) {
+        var scale = MapboxGLScale({
+            domain: [1, 3],
+            range: [2, 6],
+            property: 'mapbox'
+        });
+
+        t.equal(scale({mapbox: 1}, 3), 2);
+
+        t.end();
+    });
+
+});
 
 test('rounding', function(t) {
 
@@ -178,6 +258,4 @@ test('rounding', function(t) {
     });
 
     t.end();
-
 });
-

--- a/test/test.js
+++ b/test/test.js
@@ -29,8 +29,8 @@ test('scale isConstant', function(t) {
     t.test('constant', function(t) {
         var scale = MapboxGLScale(1);
 
-        t.equal(scale.isConstant, true);
-        t.equal(scale({}).isConstant, true);
+        t.ok(scale.isConstant);
+        t.ok(scale({}).isConstant);
 
         t.end();
     });
@@ -43,7 +43,7 @@ test('scale isConstant', function(t) {
         });
 
         t.notOk(scale.isConstant);
-        t.equal(scale({}).isConstant, true);
+        t.ok(scale({}).isConstant);
 
         t.end();
     });

--- a/test/test.js
+++ b/test/test.js
@@ -189,21 +189,5 @@ test('rounding', function(t) {
         t.end();
     });
 
-    t.test('ceiling', function(t) {
-        var scale = MapboxGLScale({
-            domain: [1, 3],
-            range: [2, 6],
-            rounding: 'ceiling'
-        });
-
-        t.equal(scale({'$zoom': 0}), 2);
-        t.equal(scale({'$zoom': 1}), 2);
-        t.equal(scale({'$zoom': 2}), 6);
-        t.equal(scale({'$zoom': 3}), 6);
-        t.equal(scale({'$zoom': 4}), 6);
-
-        t.end();
-    });
-
     t.end();
 });

--- a/test/test.js
+++ b/test/test.js
@@ -173,7 +173,7 @@ test('attribute arguments', function(t) {
             property: 'mapbox'
         });
 
-        t.equal(scale({mapbox: 1}, {google: 3}), 2);
+        t.equal(scale({mapbox: 1}, {mapbox: 3}), 2);
         t.equal(scale({google: 3}, {mapbox: 1}), 2);
 
         t.end();

--- a/test/test.js
+++ b/test/test.js
@@ -7,9 +7,9 @@ test('constant', function(t) {
     t.test('array', function(t) {
         var scale = MapboxGLScale([1]);
 
-        t.deepEqual(scale({'$zoom': 0}), [1]);
-        t.deepEqual(scale({'$zoom': 1}), [1]);
-        t.deepEqual(scale({'$zoom': 2}), [1]);
+        t.deepEqual(scale({'$zoom': 0})({}), [1]);
+        t.deepEqual(scale({'$zoom': 1})({}), [1]);
+        t.deepEqual(scale({'$zoom': 2})({}), [1]);
 
         t.end();
     });
@@ -17,9 +17,9 @@ test('constant', function(t) {
     t.test('number', function(t) {
         var scale = MapboxGLScale(1);
 
-        t.equal(scale({'$zoom': 0}), 1);
-        t.equal(scale({'$zoom': 1}), 1);
-        t.equal(scale({'$zoom': 2}), 1);
+        t.equal(scale({'$zoom': 0})({}), 1);
+        t.equal(scale({'$zoom': 1})({}), 1);
+        t.equal(scale({'$zoom': 2})({}), 1);
 
         t.end();
     });
@@ -34,9 +34,9 @@ test('domain & range', function(t) {
             range: [2]
         });
 
-        t.equal(scale({'$zoom': 0}), 2);
-        t.equal(scale({'$zoom': 1}), 2);
-        t.equal(scale({'$zoom': 2}), 2);
+        t.equal(scale({'$zoom': 0})({}), 2);
+        t.equal(scale({'$zoom': 1})({}), 2);
+        t.equal(scale({'$zoom': 2})({}), 2);
 
         t.end();
     });
@@ -47,11 +47,11 @@ test('domain & range', function(t) {
             range: [2, 6]
         });
 
-        t.equal(scale({'$zoom': 0}), 2);
-        t.equal(scale({'$zoom': 1}), 2);
-        t.equal(scale({'$zoom': 2}), 4);
-        t.equal(scale({'$zoom': 3}), 6);
-        t.equal(scale({'$zoom': 4}), 6);
+        t.equal(scale({'$zoom': 0})({}), 2);
+        t.equal(scale({'$zoom': 1})({}), 2);
+        t.equal(scale({'$zoom': 2})({}), 4);
+        t.equal(scale({'$zoom': 3})({}), 6);
+        t.equal(scale({'$zoom': 4})({}), 6);
 
         t.end();
     });
@@ -62,13 +62,13 @@ test('domain & range', function(t) {
             range: [2, 6, 10]
         });
 
-        t.equal(scale({'$zoom': 0}), 2);
-        t.equal(scale({'$zoom': 1}), 2);
-        t.equal(scale({'$zoom': 2}), 4);
-        t.equal(scale({'$zoom': 3}), 6);
-        t.equal(scale({'$zoom': 4}), 8);
-        t.equal(scale({'$zoom': 5}), 10);
-        t.equal(scale({'$zoom': 6}), 10);
+        t.equal(scale({'$zoom': 0})({}), 2);
+        t.equal(scale({'$zoom': 1})({}), 2);
+        t.equal(scale({'$zoom': 2})({}), 4);
+        t.equal(scale({'$zoom': 3})({}), 6);
+        t.equal(scale({'$zoom': 4})({}), 8);
+        t.equal(scale({'$zoom': 5})({}), 10);
+        t.equal(scale({'$zoom': 6})({}), 10);
 
         t.end();
     });
@@ -82,11 +82,40 @@ test('base', function(t) {
         base: 2
     });
 
-    t.equal(scale({'$zoom': 0}), 2);
-    t.equal(scale({'$zoom': 1}), 2);
-    t.equal(scale({'$zoom': 2}), 30 / 9);
-    t.equal(scale({'$zoom': 3}), 6);
-    t.equal(scale({'$zoom': 4}), 6);
+    t.equal(scale({'$zoom': 0})({}), 2);
+    t.equal(scale({'$zoom': 1})({}), 2);
+    t.equal(scale({'$zoom': 2})({}), 30 / 9);
+    t.equal(scale({'$zoom': 3})({}), 6);
+    t.equal(scale({'$zoom': 4})({}), 6);
+
+    t.end();
+});
+
+test('global / feature attributes', function(t) {
+
+    t.test('global', function(t) {
+        var scale = MapboxGLScale({
+            domain: [1, 3],
+            range: [2, 6],
+            property: 'mapbox'
+        });
+
+        t.equal(scale({mapbox: 2})({}), 4);
+
+        t.end();
+    });
+
+    t.test('feature', function(t) {
+        var scale = MapboxGLScale({
+            domain: [1, 3],
+            range: [2, 6],
+            property: 'mapbox'
+        });
+
+        t.equal(scale({})({mapbox: 2}), 4);
+
+        t.end();
+    });
 
     t.end();
 });
@@ -100,7 +129,7 @@ test('property', function(t) {
             property: 'mapbox'
         });
 
-        t.equal(scale({}), 2);
+        t.equal(scale({})({}), 2);
 
         t.end();
     });
@@ -112,9 +141,9 @@ test('property', function(t) {
             property: 'mapbox'
         });
 
-        t.equal(scale({mapbox: 1}), 2);
-        t.equal(scale({mapbox: 2}), 4);
-        t.equal(scale({mapbox: 3}), 6);
+        t.equal(scale({mapbox: 1})({}), 2);
+        t.equal(scale({mapbox: 2})({}), 4);
+        t.equal(scale({mapbox: 3})({}), 6);
 
         t.end();
     });
@@ -126,9 +155,9 @@ test('property', function(t) {
             property: 'mapbox'
         });
 
-        t.equal(scale({mapbox: 1, google: 3}), 2);
-        t.equal(scale({mapbox: 2, google: 3}), 4);
-        t.equal(scale({mapbox: 3, google: 0}), 6);
+        t.equal(scale({mapbox: 1, google: 3})({}), 2);
+        t.equal(scale({mapbox: 2, google: 3})({}), 4);
+        t.equal(scale({mapbox: 3, google: 0})({}), 6);
 
         t.end();
     });
@@ -145,8 +174,8 @@ test('attribute arguments', function(t) {
             property: 'mapbox'
         });
 
-        t.equal(scale({mapbox: 1}, {mapbox: 3}), 2);
-        t.equal(scale({google: 3}, {mapbox: 1}), 2);
+        t.equal(scale({mapbox: 1}, {mapbox: 3})({}), 2);
+        t.equal(scale({google: 3}, {mapbox: 1})({}), 2);
 
         t.end();
     });
@@ -162,13 +191,13 @@ test('rounding', function(t) {
             rounding: 'none'
         });
 
-        t.equal(scale({'$zoom': 0}), 2);
-        t.equal(scale({'$zoom': 1}), 2);
-        t.equal(scale({'$zoom': 1.9}), 1.9 * 2);
-        t.equal(scale({'$zoom': 2}), 4);
-        t.equal(scale({'$zoom': 2.1}), 2.1 * 2);
-        t.equal(scale({'$zoom': 3}), 6);
-        t.equal(scale({'$zoom': 4}), 6);
+        t.equal(scale({'$zoom': 0})({}), 2);
+        t.equal(scale({'$zoom': 1})({}), 2);
+        t.equal(scale({'$zoom': 1.9})({}), 1.9 * 2);
+        t.equal(scale({'$zoom': 2})({}), 4);
+        t.equal(scale({'$zoom': 2.1})({}), 2.1 * 2);
+        t.equal(scale({'$zoom': 3})({}), 6);
+        t.equal(scale({'$zoom': 4})({}), 6);
 
         t.end();
     });
@@ -180,11 +209,11 @@ test('rounding', function(t) {
             rounding: 'floor'
         });
 
-        t.equal(scale({'$zoom': 0}), 2);
-        t.equal(scale({'$zoom': 1}), 2);
-        t.equal(scale({'$zoom': 2}), 2);
-        t.equal(scale({'$zoom': 3}), 6);
-        t.equal(scale({'$zoom': 4}), 6);
+        t.equal(scale({'$zoom': 0})({}), 2);
+        t.equal(scale({'$zoom': 1})({}), 2);
+        t.equal(scale({'$zoom': 2})({}), 2);
+        t.equal(scale({'$zoom': 3})({}), 6);
+        t.equal(scale({'$zoom': 4})({}), 6);
 
         t.end();
     });


### PR DESCRIPTION
This pull request adds support for the new scale syntax including

 - added `domain` and `range` properties in addition to `steps`
 - added the ability for scales to accept more attributes (i.e. not just "zoom") and calculate outputs based on them via the `property` parameter
 - added `rounding` parameter for more flexible and explicit discrete scales
 - maintained backwards compatibility with functions

cc @ansis @jfirebaugh 