### PR TITLE
Added support for old-style function syntax

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,27 @@ module.exports = create;
 module.exports.is = is;
 
 function create(parameters) {
-    var property = parameters.property !== undefined ? parameters.property : '$zoom';
+    var property = (parameters && parameters.property !== undefined) ? parameters.property : '$zoom';
+
+    // Convert old-style functions to new-style functions
+    if (parameters.stops) {
+        var domain = [];
+        var range = [];
+
+        for (var i = 0; i < parameters.stops.length; i++) {
+            domain.push(parameters.stops[i][0]);
+            range.push(parameters.stops[i][1]);
+        }
+
+        parameters.domain = domain;
+        parameters.range = range;
+        delete parameters.stops;
+
+        if (!parameters.range.every(isInterpolatable)) {
+            parameters.domain.shift();
+            parameters.type = 'interval';
+        }
+    }
 
     var feature, global;
     var isFeatureConstant = false;
@@ -60,8 +80,6 @@ function evaluate(parameters, values) {
         return evaluateInterval(parameters, value);
     } else if (parameters.type === 'categorical') {
         return evaluateCategorical(parameters, value);
-    } else {
-        assert(false, 'Invalid function type "' + parameters.type + '"');
     }
 }
 
@@ -110,6 +128,18 @@ function evaluateExponential(parameters, value) {
     }
 }
 
+function isNumber(value) {
+    return (
+        typeof value === "number" &&
+        isFinite(value) &&
+        Math.floor(value) === value
+    );
+}
+
+function isInterpolatable(value) {
+    return isNumber(value) || (Array.isArray(value) && value.every(isNumber));
+}
+
 function interpolate(input, base, inputLower, inputUpper, outputLower, outputUpper) {
     if (outputLower.length) {
         return interpolateArray(input, base, inputLower, inputUpper, outputLower, outputUpper);
@@ -141,7 +171,7 @@ function interpolateArray(input, base, inputLower, inputUpper, outputLower, outp
 }
 
 function is(value) {
-    return typeof value === 'object' && value.range && value.domain;
+    return typeof value === 'object' && ((value.range && value.domain) || value.stops);
 }
 
 function assert(predicate, message) {

--- a/index.js
+++ b/index.js
@@ -80,6 +80,8 @@ function evaluate(parameters, values) {
         return evaluateInterval(parameters, value);
     } else if (parameters.type === 'categorical') {
         return evaluateCategorical(parameters, value);
+    } else {
+        assert(false, 'Invalid function type "' + parameters.type + '"');
     }
 }
 

--- a/test/legacy.test.js
+++ b/test/legacy.test.js
@@ -1,133 +1,89 @@
 'use strict';
 
 var test = require('tape');
-var MapboxGLScale = require('../');
-var MapboxGLStyleSpec = require('mapbox-gl-style-spec');
-
-function migrate(type, input) {
-    var inputStylesheet, outputStylesheet;
-
-    if (type === 'piecewise-constant') {
-        inputStylesheet = {
-            version: 7,
-            layers: [{
-                id: 'mapbox',
-                paint: { 'line-dasharray': input }
-            }]
-        };
-        outputStylesheet = MapboxGLStyleSpec.migrate(inputStylesheet);
-        return outputStylesheet.layers[0].paint['line-dasharray'];
-
-    } else {
-        inputStylesheet = {
-            version: 7,
-            layers: [{
-                id: 'mapbox',
-                paint: { 'line-color': input }
-            }]
-        };
-        outputStylesheet = MapboxGLStyleSpec.migrate(inputStylesheet);
-        return outputStylesheet.layers[0].paint['line-color'];
-    }
-}
-
-var func = {
-    interpolated: function(parameters) {
-        var scale = MapboxGLScale(migrate('interpolated', parameters));
-        return function(zoom) {
-            return scale({'$zoom': zoom})({});
-        };
-    },
-
-    'piecewise-constant': function(parameters) {
-        var scale = MapboxGLScale(migrate('piecewise-constant', parameters));
-        return function(zoom) {
-            return scale({'$zoom': zoom})({});
-        };
-    }
-};
+var MapboxGLFunction = require('../');
 
 test('interpolated, constant number', function(t) {
-    var f = func.interpolated(0);
-    t.equal(f(0), 0);
-    t.equal(f(1), 0);
+    var f = MapboxGLFunction(0);
+    t.equal(f({$zoom: 0})({}), 0);
+    t.equal(f({$zoom: 1})({}), 0);
     t.end();
 });
 
 test('interpolated, constant array', function(t) {
-    var f = func.interpolated([0, 0, 0, 1]);
-    t.deepEqual(f(0), [0, 0, 0, 1]);
-    t.deepEqual(f(1), [0, 0, 0, 1]);
+    var f = MapboxGLFunction([0, 0, 0, 1]);
+    t.deepEqual(f({$zoom: 0})({}), [0, 0, 0, 1]);
+    t.deepEqual(f({$zoom: 1})({}), [0, 0, 0, 1]);
     t.end();
 });
 
 test('interpolated, single stop', function(t) {
-    var f = func.interpolated({stops: [[1, 1]]});
-    t.equal(f(0), 1);
-    t.equal(f(1), 1);
-    t.equal(f(3), 1);
+    var f = MapboxGLFunction({stops: [[1, 1]]});
+    t.equal(f({$zoom: 0})({}), 1);
+    t.equal(f({$zoom: 1})({}), 1);
+    t.equal(f({$zoom: 3})({}), 1);
     t.end();
 });
 
 test('interpolated, default base', function(t) {
-    var f = func.interpolated({stops: [[1, 1], [5, 10]]});
-    t.equal(f(0), 1);
-    t.equal(f(1), 1);
-    t.equal(f(3), 5.5);
-    t.equal(f(5), 10);
-    t.equal(f(11), 10);
+    var f = MapboxGLFunction({stops: [[1, 1], [5, 10]]});
+    t.equal(f({$zoom: 0})({}), 1);
+    t.equal(f({$zoom: 1})({}), 1);
+    t.equal(f({$zoom: 3})({}), 5.5);
+    t.equal(f({$zoom: 5})({}), 10);
+    t.equal(f({$zoom: 11})({}), 10);
     t.end();
 });
 
 test('interpolated, specified base', function(t) {
-    var f = func.interpolated({stops: [[1, 1], [5, 10]], base: 2});
-    t.equal(f(0), 1);
-    t.equal(f(1), 1);
-    t.equal(f(3), 2.8);
-    t.equal(f(5), 10);
-    t.equal(f(11), 10);
+    var f = MapboxGLFunction({stops: [[1, 1], [5, 10]], base: 2});
+    t.equal(f({$zoom: 0})({}), 1);
+    t.equal(f({$zoom: 1})({}), 1);
+    t.equal(f({$zoom: 3})({}), 2.8);
+    t.equal(f({$zoom: 5})({}), 10);
+    t.equal(f({$zoom: 11})({}), 10);
     t.end();
 });
 
 test('interpolated, array', function(t) {
-    var f = func.interpolated({stops: [[1, [1, 2]], [5, [5, 10]]]});
-    t.deepEqual(f(0), [1, 2]);
-    t.deepEqual(f(1), [1, 2]);
-    t.deepEqual(f(3), [3, 6]);
-    t.deepEqual(f(5), [5, 10]);
-    t.deepEqual(f(11), [5, 10]);
+    var f = MapboxGLFunction({stops: [[1, [1, 2]], [5, [5, 10]]]});
+    t.deepEqual(f({$zoom: 0})({}), [1, 2]);
+    t.deepEqual(f({$zoom: 1})({}), [1, 2]);
+    t.deepEqual(f({$zoom: 3})({}), [3, 6]);
+    t.deepEqual(f({$zoom: 5})({}), [5, 10]);
+    t.deepEqual(f({$zoom: 11})({}), [5, 10]);
     t.end();
 });
 
 test('piecewise-constant, constant number', function(t) {
-    var f = func['piecewise-constant'](0);
-    t.equal(f(0), 0);
-    t.equal(f(1), 0);
+    var f = MapboxGLFunction(0);
+    t.equal(f({$zoom: 0})({}), 0);
+    t.equal(f({$zoom: 1})({}), 0);
     t.end();
 });
 
 test('piecewise-constant, constant array', function(t) {
-    var f = func['piecewise-constant']([0, 0, 0, 1]);
-    t.deepEqual(f(0), [0, 0, 0, 1]);
-    t.deepEqual(f(1), [0, 0, 0, 1]);
+    var f = MapboxGLFunction([0, 0, 0, 1]);
+    t.deepEqual(f({$zoom: 0})({}), [0, 0, 0, 1]);
+    t.deepEqual(f({$zoom: 1})({}), [0, 0, 0, 1]);
     t.end();
 });
 
 test('piecewise-constant, single stop', function(t) {
-    var f = func['piecewise-constant']({stops: [[1, "a"]]});
-    t.equal(f(0), "a");
-    t.equal(f(1), "a");
-    t.equal(f(3), "a");
+    var f = MapboxGLFunction({stops: [[1, "a"]]});
+    t.equal(f({$zoom: 0})({}), "a");
+    t.equal(f({$zoom: 1})({}), "a");
+    t.equal(f({$zoom: 3})({}), "a");
     t.end();
 });
 
 test('piecewise-constant, multiple stops', function(t) {
-    var f = func['piecewise-constant']({stops: [[1, "a"], [3, "b"], [4, "c"]]});
-    t.equal(f(0), "a");
-    t.equal(f(1), "a");
-    t.equal(f(2), "a");
-    t.equal(f(3), "b");
-    t.equal(f(4), "c");
-    t.equal(f(5), "c");
+    var f = MapboxGLFunction({stops: [[1, "a"], [3, "b"], [4, "c"]]});
+    t.equal(f({$zoom: 0})({}), "a");
+    t.equal(f({$zoom: 1})({}), "a");
+    t.equal(f({$zoom: 2})({}), "a");
+    t.equal(f({$zoom: 3})({}), "b");
+    t.equal(f({$zoom: 4})({}), "c");
+    t.equal(f({$zoom: 5})({}), "c");
     t.end();
 });


### PR DESCRIPTION
Changing the API in GL JS was a big pain. Instead of reverting outright, I added seamless support for the old-style syntax. There’s a little hack to get around the lack of a proper distinction between “piecewise” and  “continuous” functions but it shouldn’t be an issue for v8. 

cc @jfirebaugh 

Related to https://github.com/mapbox/mapbox-gl-js/issues/1406