### PR TITLE
Removed global / feature evaluation and property evaluation

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,89 +6,65 @@ module.exports = create;
 module.exports.is = is;
 
 function create(parameters) {
-    var property = parameters.property !== undefined ? parameters.property : '$zoom';
+    var fun;
 
-    var feature, global;
-    var isFeatureConstant = false;
-    var isGlobalConstant = false;
     if (!is(parameters)) {
-        global = function() { return feature; };
-        feature = function() { return parameters; };
-        isGlobalConstant = true;
-
-    } else if (property[0] === GLOBAL_ATTRIBUTE_PREFIX) {
-        global = function(values) {
-            var value = evaluate(parameters, values);
-            feature = function() { return value; };
-            feature.isConstant = isFeatureConstant;
-            feature.isGlobalConstant  = isGlobalConstant;
-            feature.isFeatureConstant = isFeatureConstant;
-            return feature;
-        };
-        isFeatureConstant = true;
+        fun = function() { return parameters; };
+        fun.isFeatureConstant = true;
+        fun.isGlobalConstant = true;
 
     } else {
-        global = function() { return feature; };
-        feature = function(values) { return evaluate(parameters, values); };
+        var property = parameters.property === undefined ? '$zoom' : parameters.property;
+
+        var innerFun;
+        if (!parameters.type || parameters.type === 'exponential') {
+            innerFun = evaluateExponentialFunction;
+        } else if (parameters.type === 'interval') {
+            innerFun = evaluateIntervalFunction;
+        } else if (parameters.type === 'categorical') {
+            innerFun = evaluateCategoricalFunction;
+        } else {
+            throw new Error('Unknown function type "' + parameters.type + '"');
+        }
+
+        if (property[0] === GLOBAL_ATTRIBUTE_PREFIX) {
+            fun = function(global) {
+                return innerFun(parameters, global[property]);
+            };
+            fun.isFeatureConstant = true;
+        } else {
+            fun = function(global, feature) {
+                return innerFun(parameters, feature[property]);
+            };
+        }
     }
 
-    if (isGlobalConstant) isFeatureConstant = true;
-
-    global.isConstant = isGlobalConstant;
-    global.isGlobalConstant = isGlobalConstant;
-    global.isFeatureConstant = isFeatureConstant;
-
-    if (feature) {
-        feature.isConstant = isFeatureConstant;
-        feature.isGlobalConstant  = isGlobalConstant;
-        feature.isFeatureConstant = isFeatureConstant;
-    }
-
-    return global;
+    return fun;
 }
 
-function evaluate(parameters, values) {
-    assert(typeof values === 'object');
-    var property = parameters.property !== undefined ? parameters.property : '$zoom';
-    var value = values[property];
-
-    if (value === undefined) {
-        return parameters.range[0];
-    } else if (!parameters.type || parameters.type === 'exponential') {
-        return evaluateExponential(parameters, value);
-    } else if (parameters.type === 'interval') {
-        return evaluateInterval(parameters, value);
-    } else if (parameters.type === 'categorical') {
-        return evaluateCategorical(parameters, value);
-    } else {
-        assert(false, 'Invalid function type "' + parameters.type + '"');
-    }
-}
-
-function evaluateCategorical(parameters, value) {
+function evaluateCategoricalFunction(parameters, input) {
     for (var i = 0; i < parameters.domain.length; i++) {
-        if (value === parameters.domain[i]) {
+        if (input === parameters.domain[i]) {
             return parameters.range[i];
         }
     }
     return parameters.range[0];
 }
 
-function evaluateInterval(parameters, value) {
-    assert(parameters.domain.length + 1 === parameters.range.length);
+function evaluateIntervalFunction(parameters, input) {
     for (var i = 0; i < parameters.domain.length; i++) {
-        if (value < parameters.domain[i]) break;
+        if (input < parameters.domain[i]) break;
     }
     return parameters.range[i];
 }
 
-function evaluateExponential(parameters, value) {
+function evaluateExponentialFunction(parameters, input) {
     var base = parameters.base !== undefined ? parameters.base : 1;
 
     var i = 0;
     while (true) {
         if (i >= parameters.domain.length) break;
-        else if (value <= parameters.domain[i]) break;
+        else if (input <= parameters.domain[i]) break;
         else i++;
     }
 
@@ -100,7 +76,7 @@ function evaluateExponential(parameters, value) {
 
     } else {
         return interpolate(
-            value,
+            input,
             base,
             parameters.domain[i - 1],
             parameters.domain[i],
@@ -142,10 +118,4 @@ function interpolateArray(input, base, inputLower, inputUpper, outputLower, outp
 
 function is(value) {
     return typeof value === 'object' && value.range && value.domain;
-}
-
-function assert(predicate, message) {
-    if (!predicate) {
-        throw new Error(message || 'Assertion failed');
-    }
 }

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "mapbox-gl-function",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Evaluate a Mapbox GL style function",
   "devDependencies": {
     "eslint": "^0.22.1",
-    "mapbox-gl-style-spec": "git+https://github.com/mapbox/mapbox-gl-style-spec.git#v8",
+    "mapbox-gl-style-spec": "git+https://github.com/mapbox/mapbox-gl-style-spec.git#v9",
     "tape": "^3.5.0"
   },
   "scripts": {

--- a/test/legacy.test.js
+++ b/test/legacy.test.js
@@ -35,14 +35,14 @@ var func = {
     interpolated: function(parameters) {
         var scale = MapboxGLScale(migrate('interpolated', parameters));
         return function(zoom) {
-            return scale({'$zoom': zoom})({});
+            return scale({'$zoom': zoom});
         };
     },
 
     'piecewise-constant': function(parameters) {
         var scale = MapboxGLScale(migrate('piecewise-constant', parameters));
         return function(zoom) {
-            return scale({'$zoom': zoom})({});
+            return scale({'$zoom': zoom});
         };
     }
 };

--- a/test/test.js
+++ b/test/test.js
@@ -12,9 +12,9 @@ test('function types', function(t) {
             t.test('array', function(t) {
                 var f = MapboxGLScale([1]);
 
-                t.deepEqual(f({'$zoom': 0})({}), [1]);
-                t.deepEqual(f({'$zoom': 1})({}), [1]);
-                t.deepEqual(f({'$zoom': 2})({}), [1]);
+                t.deepEqual(f({$zoom: 0}), [1]);
+                t.deepEqual(f({$zoom: 1}), [1]);
+                t.deepEqual(f({$zoom: 2}), [1]);
 
                 t.end();
             });
@@ -22,9 +22,9 @@ test('function types', function(t) {
             t.test('number', function(t) {
                 var f = MapboxGLScale(1);
 
-                t.equal(f({'$zoom': 0})({}), 1);
-                t.equal(f({'$zoom': 1})({}), 1);
-                t.equal(f({'$zoom': 2})({}), 1);
+                t.equal(f({$zoom: 0}), 1);
+                t.equal(f({$zoom: 1}), 1);
+                t.equal(f({$zoom: 2}), 1);
 
                 t.end();
             });
@@ -32,9 +32,9 @@ test('function types', function(t) {
             t.test('string', function(t) {
                 var f = MapboxGLScale('mapbox');
 
-                t.equal(f({'$zoom': 0})({}), 'mapbox');
-                t.equal(f({'$zoom': 1})({}), 'mapbox');
-                t.equal(f({'$zoom': 2})({}), 'mapbox');
+                t.equal(f({$zoom: 0}), 'mapbox');
+                t.equal(f({$zoom: 1}), 'mapbox');
+                t.equal(f({$zoom: 2}), 'mapbox');
 
                 t.end();
             });
@@ -53,11 +53,11 @@ test('function types', function(t) {
                 base: 2
             });
 
-            t.equal(f({'$zoom': 0})({}), 2);
-            t.equal(f({'$zoom': 1})({}), 2);
-            t.equal(f({'$zoom': 2})({}), 30 / 9);
-            t.equal(f({'$zoom': 3})({}), 6);
-            t.equal(f({'$zoom': 4})({}), 6);
+            t.equal(f({$zoom: 0}), 2);
+            t.equal(f({$zoom: 1}), 2);
+            t.equal(f({$zoom: 2}), 30 / 9);
+            t.equal(f({$zoom: 3}), 6);
+            t.equal(f({$zoom: 4}), 6);
 
             t.end();
         });
@@ -70,9 +70,9 @@ test('function types', function(t) {
                     range: [2]
                 });
 
-                t.equal(f({'$zoom': 0})({}), 2);
-                t.equal(f({'$zoom': 1})({}), 2);
-                t.equal(f({'$zoom': 2})({}), 2);
+                t.equal(f({$zoom: 0}), 2);
+                t.equal(f({$zoom: 1}), 2);
+                t.equal(f({$zoom: 2}), 2);
 
                 t.end();
             });
@@ -84,11 +84,11 @@ test('function types', function(t) {
                     range: [2, 6]
                 });
 
-                t.equal(f({'$zoom': 0})({}), 2);
-                t.equal(f({'$zoom': 1})({}), 2);
-                t.equal(f({'$zoom': 2})({}), 4);
-                t.equal(f({'$zoom': 3})({}), 6);
-                t.equal(f({'$zoom': 4})({}), 6);
+                t.equal(f({$zoom: 0}), 2);
+                t.equal(f({$zoom: 1}), 2);
+                t.equal(f({$zoom: 2}), 4);
+                t.equal(f({$zoom: 3}), 6);
+                t.equal(f({$zoom: 4}), 6);
 
                 t.end();
             });
@@ -100,13 +100,13 @@ test('function types', function(t) {
                     range: [2, 6, 10]
                 });
 
-                t.equal(f({'$zoom': 0})({}), 2);
-                t.equal(f({'$zoom': 1})({}), 2);
-                t.equal(f({'$zoom': 2})({}), 4);
-                t.equal(f({'$zoom': 3})({}), 6);
-                t.equal(f({'$zoom': 4})({}), 8);
-                t.equal(f({'$zoom': 5})({}), 10);
-                t.equal(f({'$zoom': 6})({}), 10);
+                t.equal(f({$zoom: 0}), 2);
+                t.equal(f({$zoom: 1}), 2);
+                t.equal(f({$zoom: 2}), 4);
+                t.equal(f({$zoom: 3}), 6);
+                t.equal(f({$zoom: 4}), 8);
+                t.equal(f({$zoom: 5}), 10);
+                t.equal(f({$zoom: 6}), 10);
 
                 t.end();
             });
@@ -121,12 +121,11 @@ test('function types', function(t) {
             var f = MapboxGLScale({
                 type: 'categorical',
                 domain: ['umpteen'],
-                range: [42],
-                property: 'mapbox'
+                range: [42]
             });
 
-            t.equal(f({})({mapbox: 'umpteen'}), 42);
-            t.equal(f({})({mapbox: 'derp'}), 42);
+            t.equal(f({$zoom: 'umpteen'}), 42);
+            t.equal(f({$zoom: 'derp'}), 42);
 
             t.end();
         });
@@ -135,13 +134,12 @@ test('function types', function(t) {
             var f = MapboxGLScale({
                 type: 'categorical',
                 domain: ['umpteen', 'eleventy'],
-                range: [42, 110],
-                property: 'mapbox'
+                range: [42, 110]
             });
 
-            t.equal(f({})({mapbox: 'umpteen'}), 42);
-            t.equal(f({})({mapbox: 'eleventy'}), 110);
-            t.equal(f({})({mapbox: 'derp'}), 42);
+            t.equal(f({$zoom: 'umpteen'}), 42);
+            t.equal(f({$zoom: 'eleventy'}), 110);
+            t.equal(f({$zoom: 'derp'}), 42);
 
 
             t.end();
@@ -155,13 +153,12 @@ test('function types', function(t) {
             var f = MapboxGLScale({
                 type: 'interval',
                 domain: [0],
-                range: [11, 111],
-                property: 'mapbox'
+                range: [11, 111]
             });
 
-            t.equal(f({})({mapbox: -0.5}), 11);
-            t.equal(f({})({mapbox: 0}), 111);
-            t.equal(f({})({mapbox: 0.5}), 111);
+            t.equal(f({$zoom: -0.5}), 11);
+            t.equal(f({$zoom: 0}), 111);
+            t.equal(f({$zoom: 0.5}), 111);
 
             t.end();
         });
@@ -170,15 +167,14 @@ test('function types', function(t) {
             var f = MapboxGLScale({
                 type: 'interval',
                 domain: [0, 1],
-                range: [11, 111, 1111],
-                property: 'mapbox'
+                range: [11, 111, 1111]
             });
 
-            t.equal(f({})({mapbox: -0.5}), 11);
-            t.equal(f({})({mapbox: 0}), 111);
-            t.equal(f({})({mapbox: 0.5}), 111);
-            t.equal(f({})({mapbox: 1}), 1111);
-            t.equal(f({})({mapbox: 1.5}), 1111);
+            t.equal(f({$zoom: -0.5}), 11);
+            t.equal(f({$zoom: 0}), 111);
+            t.equal(f({$zoom: 0.5}), 111);
+            t.equal(f({$zoom: 1}), 1111);
+            t.equal(f({$zoom: 1.5}), 1111);
 
             t.end();
         });
@@ -193,11 +189,10 @@ test('property', function(t) {
         var f = MapboxGLScale({
             type: 'categorical',
             domain: ['map', 'box'],
-            range: ['neat', 'swell'],
-            property: 'mapbox'
+            range: ['neat', 'swell']
         });
 
-        t.equal(f({})({}), 'neat');
+        t.equal(f({$zoom: 'box'}), 'swell');
 
         t.end();
     });
@@ -207,10 +202,10 @@ test('property', function(t) {
             type: 'categorical',
             domain: ['map', 'box'],
             range: ['neat', 'swell'],
-            property: 'mapbox'
+            property: '$mapbox'
         });
 
-        t.equal(f({})({mapbox: 'box'}), 'swell');
+        t.equal(f({$mapbox: 'box'}), 'swell');
 
         t.end();
     });
@@ -223,7 +218,7 @@ test('property', function(t) {
             property: 'mapbox'
         });
 
-        t.equal(f({})({mapbox: 'box'}), 'swell');
+        t.equal(f({}, {mapbox: 'box'}), 'swell');
 
         t.end();
     });
@@ -236,14 +231,8 @@ test('isConstant', function(t) {
     t.test('constant', function(t) {
         var f = MapboxGLScale(1);
 
-        t.ok(f.isConstant);
-        t.ok(f({}).isConstant);
-
         t.ok(f.isGlobalConstant);
-        t.ok(f({}).isGlobalConstant);
-
         t.ok(f.isFeatureConstant);
-        t.ok(f({}).isFeatureConstant);
 
         t.end();
     });
@@ -252,17 +241,11 @@ test('isConstant', function(t) {
         var f = MapboxGLScale({
             domain: [1],
             range: [1],
-            property: '$zoom'
+            property: '$mapbox'
         });
 
-        t.notOk(f.isConstant);
-        t.ok(f({}).isConstant);
-
         t.notOk(f.isGlobalConstant);
-        t.notOk(f({}).isGlobalConstant);
-
         t.ok(f.isFeatureConstant);
-        t.ok(f({}).isFeatureConstant);
 
         t.end();
     });
@@ -274,14 +257,8 @@ test('isConstant', function(t) {
             property: 'mapbox'
         });
 
-        t.notOk(f.isConstant);
-        t.notOk(f({}).isConstant);
-
         t.notOk(f.isGlobalConstant);
-        t.notOk(f({}).isGlobalConstant);
-
         t.notOk(f.isFeatureConstant);
-        t.notOk(f({}).isFeatureConstant);
 
         t.end();
     });


### PR DESCRIPTION
With great humility & hindsight, I revisit some of the first code I wrote at Mapbox to simplify the API and improve perf

 - remove the global / feature nested evaluation (i.e. `f(global)(feature)`) in favor of a single evaluation (i.e. `f(input)`)
 - remove property object evaluation (i.e. `f({$zoom: zoom})`) in favor of simple evaluation (i.e. `f(zoom)`)
 - remove `assert` function (bad for perf and causes [mapbox-gl-js tests](https://github.com/mapbox/mapbox-gl-js/blob/master/test/js/build/build.test.js#L6) to fail) 

These are breaking API changes but nobody is using 2.0 in the wild, so I vote we release this as version 2.1 once the dust settles.

cc @jfirebaugh @ansis 