### PR TITLE
Make data-driven styling functions backwards-compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,21 +7,21 @@ Note that other Mapbox tools currently use v1, not v2.
 ``` javascript
 var glfun = require('mapbox-gl-function');
 
-var exponential = glfun({type: 'exponential', domain: [1, 5], range: [1, 10]});
+var exponential = glfun({type: 'exponential', stops: [[1, 1], [5, 10]]});
 exponential({ $zoom: 0 });  // => 1
 exponential({ $zoom: 1 });  // => 1
 exponential({ $zoom: 3 });  // => 5.5
 exponential({ $zoom: 5 });  // => 10
 exponential({ $zoom: 11 }); // => 10
 
-var interval = glfun({type: 'interval', domain: [1, 3, 4], range: ['a', 'b', 'c']});
+var interval = glfun({type: 'interval', stops: [[1, 'a'], [3, 'b'], [4, 'c']]});
 interval({ $zoom: 0 }); // => 'a'
 interval({ $zoom: 1 }); // => 'a'
 interval({ $zoom: 2 }); // => 'a'
 interval({ $zoom: 3 }); // => 'b'
 interval({ $zoom: 4 }); // => 'c'
 
-var categorical = glfun({type: 'categorical', domain: ['A', 'B', 'C'], range: ['a', 'b', 'c']});
+var categorical = glfun({type: 'categorical', stops: [['A', 'a'], ['B', 'b'], ['C', 'c']]});
 categorical({ $zoom: 'A' }); // => 'a'
 categorical({ $zoom: 'B' }); // => 'b'
 categorical({ $zoom: 'C' }); // => 'c'

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "mapbox-gl-function",
-  "version": "2.1.0",
+  "version": "1.1.0",
   "description": "Evaluate a Mapbox GL style function",
   "devDependencies": {
     "eslint": "^0.22.1",
-    "mapbox-gl-style-spec": "git+https://github.com/mapbox/mapbox-gl-style-spec.git#aae9d8c08cae5299deea0b2c86d270ef3dc7cac1",
+    "mapbox-gl-style-spec": "mapbox/mapbox-gl-style-spec#fe8f3a3644d38fda8558868f397dbdff3989af67",
     "tape": "^3.5.0"
   },
   "scripts": {

--- a/test/legacy.test.js
+++ b/test/legacy.test.js
@@ -1,68 +1,24 @@
 'use strict';
 
 var test = require('tape');
-var MapboxGLScale = require('../');
-var MapboxGLStyleSpec = require('mapbox-gl-style-spec');
-
-function migrate(type, input) {
-    var inputStylesheet, outputStylesheet;
-
-    if (type === 'piecewise-constant') {
-        inputStylesheet = {
-            version: 7,
-            layers: [{
-                id: 'mapbox',
-                paint: { 'line-dasharray': input }
-            }]
-        };
-        outputStylesheet = MapboxGLStyleSpec.migrate(inputStylesheet);
-        return outputStylesheet.layers[0].paint['line-dasharray'];
-
-    } else {
-        inputStylesheet = {
-            version: 7,
-            layers: [{
-                id: 'mapbox',
-                paint: { 'line-color': input }
-            }]
-        };
-        outputStylesheet = MapboxGLStyleSpec.migrate(inputStylesheet);
-        return outputStylesheet.layers[0].paint['line-color'];
-    }
-}
-
-var func = {
-    interpolated: function(parameters) {
-        var scale = MapboxGLScale(migrate('interpolated', parameters));
-        return function(zoom) {
-            return scale({'$zoom': zoom});
-        };
-    },
-
-    'piecewise-constant': function(parameters) {
-        var scale = MapboxGLScale(migrate('piecewise-constant', parameters));
-        return function(zoom) {
-            return scale({'$zoom': zoom});
-        };
-    }
-};
+var MapboxGLFunction = require('../');
 
 test('interpolated, constant number', function(t) {
-    var f = func.interpolated(0);
+    var f = MapboxGLFunction.interpolated(0);
     t.equal(f(0), 0);
     t.equal(f(1), 0);
     t.end();
 });
 
 test('interpolated, constant array', function(t) {
-    var f = func.interpolated([0, 0, 0, 1]);
+    var f = MapboxGLFunction.interpolated([0, 0, 0, 1]);
     t.deepEqual(f(0), [0, 0, 0, 1]);
     t.deepEqual(f(1), [0, 0, 0, 1]);
     t.end();
 });
 
 test('interpolated, single stop', function(t) {
-    var f = func.interpolated({stops: [[1, 1]]});
+    var f = MapboxGLFunction.interpolated({stops: [[1, 1]]});
     t.equal(f(0), 1);
     t.equal(f(1), 1);
     t.equal(f(3), 1);
@@ -70,7 +26,7 @@ test('interpolated, single stop', function(t) {
 });
 
 test('interpolated, default base', function(t) {
-    var f = func.interpolated({stops: [[1, 1], [5, 10]]});
+    var f = MapboxGLFunction.interpolated({stops: [[1, 1], [5, 10]]});
     t.equal(f(0), 1);
     t.equal(f(1), 1);
     t.equal(f(3), 5.5);
@@ -80,7 +36,7 @@ test('interpolated, default base', function(t) {
 });
 
 test('interpolated, specified base', function(t) {
-    var f = func.interpolated({stops: [[1, 1], [5, 10]], base: 2});
+    var f = MapboxGLFunction.interpolated({stops: [[1, 1], [5, 10]], base: 2});
     t.equal(f(0), 1);
     t.equal(f(1), 1);
     t.equal(f(3), 2.8);
@@ -90,7 +46,7 @@ test('interpolated, specified base', function(t) {
 });
 
 test('interpolated, array', function(t) {
-    var f = func.interpolated({stops: [[1, [1, 2]], [5, [5, 10]]]});
+    var f = MapboxGLFunction.interpolated({stops: [[1, [1, 2]], [5, [5, 10]]]});
     t.deepEqual(f(0), [1, 2]);
     t.deepEqual(f(1), [1, 2]);
     t.deepEqual(f(3), [3, 6]);
@@ -100,21 +56,21 @@ test('interpolated, array', function(t) {
 });
 
 test('piecewise-constant, constant number', function(t) {
-    var f = func['piecewise-constant'](0);
+    var f = MapboxGLFunction['piecewise-constant'](0);
     t.equal(f(0), 0);
     t.equal(f(1), 0);
     t.end();
 });
 
 test('piecewise-constant, constant array', function(t) {
-    var f = func['piecewise-constant']([0, 0, 0, 1]);
+    var f = MapboxGLFunction['piecewise-constant']([0, 0, 0, 1]);
     t.deepEqual(f(0), [0, 0, 0, 1]);
     t.deepEqual(f(1), [0, 0, 0, 1]);
     t.end();
 });
 
 test('piecewise-constant, single stop', function(t) {
-    var f = func['piecewise-constant']({stops: [[1, "a"]]});
+    var f = MapboxGLFunction['piecewise-constant']({stops: [[1, "a"]]});
     t.equal(f(0), "a");
     t.equal(f(1), "a");
     t.equal(f(3), "a");
@@ -122,7 +78,7 @@ test('piecewise-constant, single stop', function(t) {
 });
 
 test('piecewise-constant, multiple stops', function(t) {
-    var f = func['piecewise-constant']({stops: [[1, "a"], [3, "b"], [4, "c"]]});
+    var f = MapboxGLFunction['piecewise-constant']({stops: [[1, "a"], [3, "b"], [4, "c"]]});
     t.equal(f(0), "a");
     t.equal(f(1), "a");
     t.equal(f(2), "a");

--- a/test/test.js
+++ b/test/test.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var test = require('tape');
-var MapboxGLScale = require('../');
+var MapboxGLFunction = require('../').interpolated;
 
 test('function types', function(t) {
 
@@ -10,31 +10,31 @@ test('function types', function(t) {
         t.test('range types', function(t) {
 
             t.test('array', function(t) {
-                var f = MapboxGLScale([1]);
+                var f = MapboxGLFunction([1]);
 
-                t.deepEqual(f({$zoom: 0}), [1]);
-                t.deepEqual(f({$zoom: 1}), [1]);
-                t.deepEqual(f({$zoom: 2}), [1]);
+                t.deepEqual(f(0), [1]);
+                t.deepEqual(f(1), [1]);
+                t.deepEqual(f(2), [1]);
 
                 t.end();
             });
 
             t.test('number', function(t) {
-                var f = MapboxGLScale(1);
+                var f = MapboxGLFunction(1);
 
-                t.equal(f({$zoom: 0}), 1);
-                t.equal(f({$zoom: 1}), 1);
-                t.equal(f({$zoom: 2}), 1);
+                t.equal(f(0), 1);
+                t.equal(f(1), 1);
+                t.equal(f(2), 1);
 
                 t.end();
             });
 
             t.test('string', function(t) {
-                var f = MapboxGLScale('mapbox');
+                var f = MapboxGLFunction('mapbox');
 
-                t.equal(f({$zoom: 0}), 'mapbox');
-                t.equal(f({$zoom: 1}), 'mapbox');
-                t.equal(f({$zoom: 2}), 'mapbox');
+                t.equal(f(0), 'mapbox');
+                t.equal(f(1), 'mapbox');
+                t.equal(f(2), 'mapbox');
 
                 t.end();
             });
@@ -46,67 +46,63 @@ test('function types', function(t) {
     t.test('exponential', function(t) {
 
         t.test('base', function(t) {
-            var f = MapboxGLScale({
+            var f = MapboxGLFunction({
                 type: 'exponential',
-                domain: [1, 3],
-                range: [2, 6],
+                stops: [[1, 2], [3, 6]],
                 base: 2
             });
 
-            t.equal(f({$zoom: 0}), 2);
-            t.equal(f({$zoom: 1}), 2);
-            t.equal(f({$zoom: 2}), 30 / 9);
-            t.equal(f({$zoom: 3}), 6);
-            t.equal(f({$zoom: 4}), 6);
+            t.equal(f(0), 2);
+            t.equal(f(1), 2);
+            t.equal(f(2), 30 / 9);
+            t.equal(f(3), 6);
+            t.equal(f(4), 6);
 
             t.end();
         });
 
-        t.test('domain & range', function(t) {
+        t.test('stops', function(t) {
             t.test('one element', function(t) {
-                var f = MapboxGLScale({
+                var f = MapboxGLFunction({
                     type: 'exponential',
-                    domain: [1],
-                    range: [2]
+                    stops: [[1, 2]]
                 });
 
-                t.equal(f({$zoom: 0}), 2);
-                t.equal(f({$zoom: 1}), 2);
-                t.equal(f({$zoom: 2}), 2);
+                t.equal(f(0), 2);
+                t.equal(f(1), 2);
+                t.equal(f(2), 2);
 
                 t.end();
             });
 
             t.test('two elements', function(t) {
-                var f = MapboxGLScale({
+                var f = MapboxGLFunction({
                     type: 'exponential',
-                    domain: [1, 3],
-                    range: [2, 6]
+                    stops: [[1, 2], [3, 6]]
                 });
 
-                t.equal(f({$zoom: 0}), 2);
-                t.equal(f({$zoom: 1}), 2);
-                t.equal(f({$zoom: 2}), 4);
-                t.equal(f({$zoom: 3}), 6);
-                t.equal(f({$zoom: 4}), 6);
+                t.equal(f(0), 2);
+                t.equal(f(1), 2);
+                t.equal(f(2), 4);
+                t.equal(f(3), 6);
+                t.equal(f(4), 6);
 
                 t.end();
             });
 
             t.test('three elements', function(t) {
-                var f = MapboxGLScale({
+                var f = MapboxGLFunction({
                     type: 'exponential',
-                    domain: [1, 3, 5],
-                    range: [2, 6, 10]
+                    stops: [[1, 2], [3, 6], [5, 10]]
                 });
 
-                t.equal(f({$zoom: 0}), 2);
-                t.equal(f({$zoom: 1}), 2);
-                t.equal(f({$zoom: 2}), 4);
-                t.equal(f({$zoom: 3}), 6);
-                t.equal(f({$zoom: 4}), 8);
-                t.equal(f({$zoom: 5}), 10);
-                t.equal(f({$zoom: 6}), 10);
+                t.equal(f(0), 2);
+                t.equal(f(1), 2);
+                t.equal(f(2), 4);
+                t.equal(f(3), 6);
+                t.equal(f(4), 8);
+                t.equal(f(5), 10);
+                t.equal(f(6), 10);
 
                 t.end();
             });
@@ -118,29 +114,26 @@ test('function types', function(t) {
     t.test('categorical', function(t) {
 
         t.test('one element', function(t) {
-            var f = MapboxGLScale({
+            var f = MapboxGLFunction({
                 type: 'categorical',
-                domain: ['umpteen'],
-                range: [42]
+                stops: [['umpteen', 42]]
             });
 
-            t.equal(f({$zoom: 'umpteen'}), 42);
-            t.equal(f({$zoom: 'derp'}), 42);
+            t.equal(f('umpteen'), 42);
+            t.equal(f('derp'), 42);
 
             t.end();
         });
 
         t.test('two elements', function(t) {
-            var f = MapboxGLScale({
+            var f = MapboxGLFunction({
                 type: 'categorical',
-                domain: ['umpteen', 'eleventy'],
-                range: [42, 110]
+                stops: [['umpteen', 42], ['eleventy', 110]]
             });
 
-            t.equal(f({$zoom: 'umpteen'}), 42);
-            t.equal(f({$zoom: 'eleventy'}), 110);
-            t.equal(f({$zoom: 'derp'}), 42);
-
+            t.equal(f('umpteen'), 42);
+            t.equal(f('eleventy'), 110);
+            t.equal(f('derp'), 42);
 
             t.end();
         });
@@ -149,32 +142,45 @@ test('function types', function(t) {
 
     t.test('interval', function(t) {
 
-        t.test('one domain element', function(t) {
-            var f = MapboxGLScale({
+        t.test('one domain elements', function(t) {
+            var f = MapboxGLFunction({
                 type: 'interval',
-                domain: [0],
-                range: [11, 111]
+                stops: [[0, 11]]
             });
 
-            t.equal(f({$zoom: -0.5}), 11);
-            t.equal(f({$zoom: 0}), 111);
-            t.equal(f({$zoom: 0.5}), 111);
+            t.equal(f(-0.5), 11);
+            t.equal(f(0), 11);
+            t.equal(f(0.5), 11);
 
             t.end();
         });
 
         t.test('two domain elements', function(t) {
-            var f = MapboxGLScale({
+            var f = MapboxGLFunction({
                 type: 'interval',
-                domain: [0, 1],
-                range: [11, 111, 1111]
+                stops: [[-1, 11], [0, 111]]
             });
 
-            t.equal(f({$zoom: -0.5}), 11);
-            t.equal(f({$zoom: 0}), 111);
-            t.equal(f({$zoom: 0.5}), 111);
-            t.equal(f({$zoom: 1}), 1111);
-            t.equal(f({$zoom: 1.5}), 1111);
+            t.equal(f(-1.5), 11);
+            t.equal(f(-0.5), 11);
+            t.equal(f(0), 111);
+            t.equal(f(0.5), 111);
+
+            t.end();
+        });
+
+        t.test('three domain elements', function(t) {
+            var f = MapboxGLFunction({
+                type: 'interval',
+                stops: [[-1, 11], [0, 111], [1, 1111]]
+            });
+
+            t.equal(f(-1.5), 11);
+            t.equal(f(-0.5), 11);
+            t.equal(f(0), 111);
+            t.equal(f(0.5), 111);
+            t.equal(f(1), 1111);
+            t.equal(f(1.5), 1111);
 
             t.end();
         });
@@ -186,35 +192,32 @@ test('function types', function(t) {
 test('property', function(t) {
 
     t.test('missing property', function(t) {
-        var f = MapboxGLScale({
+        var f = MapboxGLFunction({
             type: 'categorical',
-            domain: ['map', 'box'],
-            range: ['neat', 'swell']
+            stops: [['map', 'neat'], ['box', 'swell']]
         });
 
-        t.equal(f({$zoom: 'box'}), 'swell');
+        t.equal(f('box'), 'swell');
 
         t.end();
     });
 
-    t.test('global property', function(t) {
-        var f = MapboxGLScale({
+    t.test('$zoom', function(t) {
+        var f = MapboxGLFunction({
             type: 'categorical',
-            domain: ['map', 'box'],
-            range: ['neat', 'swell'],
-            property: '$mapbox'
+            stops: [['map', 'neat'], ['box', 'swell']],
+            property: '$zoom'
         });
 
-        t.equal(f({$mapbox: 'box'}), 'swell');
+        t.equal(f('box'), 'swell');
 
         t.end();
     });
 
     t.test('feature property', function(t) {
-        var f = MapboxGLScale({
+        var f = MapboxGLFunction({
             type: 'categorical',
-            domain: ['map', 'box'],
-            range: ['neat', 'swell'],
+            stops: [['map', 'neat'], ['box', 'swell']],
             property: 'mapbox'
         });
 
@@ -229,7 +232,7 @@ test('property', function(t) {
 test('isConstant', function(t) {
 
     t.test('constant', function(t) {
-        var f = MapboxGLScale(1);
+        var f = MapboxGLFunction(1);
 
         t.ok(f.isGlobalConstant);
         t.ok(f.isFeatureConstant);
@@ -237,11 +240,10 @@ test('isConstant', function(t) {
         t.end();
     });
 
-    t.test('global', function(t) {
-        var f = MapboxGLScale({
-            domain: [1],
-            range: [1],
-            property: '$mapbox'
+    t.test('zoom', function(t) {
+        var f = MapboxGLFunction({
+            stops: [[1, 1]],
+            property: '$zoom'
         });
 
         t.notOk(f.isGlobalConstant);
@@ -251,9 +253,8 @@ test('isConstant', function(t) {
     });
 
     t.test('feature', function(t) {
-        var f = MapboxGLScale({
-            domain: [1],
-            range: [1],
+        var f = MapboxGLFunction({
+            stops: [[1, 1]],
             property: 'mapbox'
         });
 


### PR DESCRIPTION
I have reframed the data-driven styling function syntax in a way that is backwards-compatible with v1 functions. This allows us to merge data-driven styling into `mapbox-gl-js` before it is ported to `mapbox-gl-native`.

cc @jfirebaugh @ansis @bhousel @tmcw 