### PR TITLE
Fix exponential interpolation

### DIFF
--- a/index.js
+++ b/index.js
@@ -135,7 +135,7 @@ function interpolateNumber(input, base, inputLower, inputUpper, outputLower, out
     if (base === 1) {
         ratio = progress / difference;
     } else {
-        ratio = (Math.pow(base, progress) - 1) / (Math.pow(base, difference) - 1);
+        ratio = Math.pow(base, progress - difference);
     }
 
     return (outputLower * (1 - ratio)) + (outputUpper * ratio);

--- a/test/legacy.test.js
+++ b/test/legacy.test.js
@@ -39,7 +39,7 @@ test('interpolated, specified base', function(t) {
     var f = MapboxGLFunction.interpolated({stops: [[1, 1], [5, 10]], base: 2});
     t.equal(f(0), 1);
     t.equal(f(1), 1);
-    t.equal(f(3), 2.8);
+    t.equal(f(3), 3.25);
     t.equal(f(5), 10);
     t.equal(f(11), 10);
     t.end();

--- a/test/test.js
+++ b/test/test.js
@@ -45,6 +45,29 @@ test('function types', function(t) {
 
     t.test('exponential', function(t) {
 
+        t.test('base 0', function(t) {
+            var f = MapboxGLFunction({
+                type: 'exponential',
+                stops: [[0, 0], [20, 1024]],
+                base: 2
+            });
+
+            t.equal(f(0), 0);
+            t.equal(f(10), 1);
+            t.equal(f(11), 2);
+            t.equal(f(12), 4);
+            t.equal(f(13), 8);
+            t.equal(f(14), 16);
+            t.equal(f(15), 32);
+            t.equal(f(16), 64);
+            t.equal(f(17), 128);
+            t.equal(f(18), 256);
+            t.equal(f(19), 512);
+            t.equal(f(20), 1024);
+
+            t.end();
+        });
+
         t.test('base', function(t) {
             var f = MapboxGLFunction({
                 type: 'exponential',
@@ -54,7 +77,7 @@ test('function types', function(t) {
 
             t.equal(f(0), 2);
             t.equal(f(1), 2);
-            t.equal(f(2), 30 / 9);
+            t.equal(f(2), 4);
             t.equal(f(3), 6);
             t.equal(f(4), 6);
 


### PR DESCRIPTION
For some reason, the exponential interpolation was doing some weird subtractions. These subtractions broke the exponential interpolation such that, with a base of 2, a reduction of zoom level by 1 wouldn't yield a precise size reduction of factor 2.

This can be reproduced with a circle of sufficient size (e.g. 1000km) and a function of the form:

```
{
    type: 'exponential',
    stops: [[0, 0], [20, 1024]],
    base: 2
}
```

I expect the circle to maintain a fixed size relative to the map, i.e.  the circle border should always lie on the same coordinates. Currently, due to these subtractions, the circle increases in relative size with reducing zoom level.

This commit removes the unnecessary subtraction, yielding a smooth division by the base in the example above, such that the circle no longer changes in size when modifying the zoom level.

Here are some gifs showing the problem:

**Wrong** (notice how the circle sometimes fully includes Lithuania and sometimes not)

![wrong](https://cloud.githubusercontent.com/assets/128151/16408385/c2eb22b0-3d18-11e6-9dfc-673403159570.gif)

**Correct** (notice how the circle border stays on the same spot)

![correct](https://cloud.githubusercontent.com/assets/128151/16408399/d63028a2-3d18-11e6-8b86-4a55cd0c50be.gif)
