### PR TITLE
Adds support for overflowing stops

### DIFF
--- a/index.js
+++ b/index.js
@@ -114,8 +114,8 @@ function evaluateExponentialFunction(parameters, input) {
 }
 
 function calculateOverflow(input, base, stop, prevStop) {
-    if(typeof stop[1] === 'function') return stop[1];
-    if(stop[1].length) {
+    if (typeof stop[1] === 'function') return stop[1];
+    if (stop[1].length) {
         var output = [];
         for (var i = 0; i < stop[1].length; i++) {
             output[i] = calculateOverflow(input, base, stop[1][i]);
@@ -123,11 +123,11 @@ function calculateOverflow(input, base, stop, prevStop) {
         return output;
     }
 
-    if(base == 1) {
+    if (base === 1) {
         var diff = input - stop[0];
 
         var slope = 1;
-        if(prevStop) slope = (prevStop[1] - stop[1]) / (prevStop[0] - stop[0]);
+        if (prevStop) slope = (prevStop[1] - stop[1]) / (prevStop[0] - stop[0]);
 
         return stop[1] + diff * slope;
     } else {

--- a/test/test.js
+++ b/test/test.js
@@ -226,8 +226,8 @@ test('function types', function(t) {
                     overflow: true
                 });
 
-                t.equal(f(1), 1/2048);
-                t.equal(f(5), 1/128);
+                t.equal(f(1), 1 / 2048);
+                t.equal(f(5), 1 / 128);
                 t.equal(f(11), 0.5);
                 t.equal(f(12), 1);
                 t.equal(f(13), 2);
@@ -245,8 +245,8 @@ test('function types', function(t) {
                     overflow: true
                 });
 
-                t.equal(f(1), 1/1024);
-                t.equal(f(5), 1/64);
+                t.equal(f(1), 1 / 1024);
+                t.equal(f(5), 1 / 64);
                 t.equal(f(11), 1);
                 t.equal(f(12), 2);
                 t.equal(f(13), 4);

--- a/test/test.js
+++ b/test/test.js
@@ -198,6 +198,270 @@ test('function types', function(t) {
 
         });
 
+        t.test('overflow', function(t) {
+            t.test('single stop linear', function(t) {
+                var f = MapboxGLFunction({
+                    type: 'exponential',
+                    stops: [[12, 12]],
+                    base: 1,
+                    overflow: true
+                });
+
+                t.equal(f(1), 1);
+                t.equal(f(5), 5);
+                t.equal(f(11), 11);
+                t.equal(f(12), 12);
+                t.equal(f(13), 13);
+                t.equal(f(15), 15);
+                t.equal(f(20), 20);
+
+                t.end();
+            });
+
+            t.test('single stop exponential', function(t) {
+                var f = MapboxGLFunction({
+                    type: 'exponential',
+                    stops: [[12, 1]],
+                    base: 2,
+                    overflow: true
+                });
+
+                t.equal(f(1), 1/2048);
+                t.equal(f(5), 1/128);
+                t.equal(f(11), 0.5);
+                t.equal(f(12), 1);
+                t.equal(f(13), 2);
+                t.equal(f(15), 8);
+                t.equal(f(20), 256);
+
+                t.end();
+            });
+
+            t.test('single stop exponential with other start value', function(t) {
+                var f = MapboxGLFunction({
+                    type: 'exponential',
+                    stops: [[12, 2]],
+                    base: 2,
+                    overflow: true
+                });
+
+                t.equal(f(1), 1/1024);
+                t.equal(f(5), 1/64);
+                t.equal(f(11), 1);
+                t.equal(f(12), 2);
+                t.equal(f(13), 4);
+                t.equal(f(15), 16);
+                t.equal(f(20), 512);
+
+                t.end();
+            });
+
+            t.test('single stop exponential with other base', function(t) {
+                var f = MapboxGLFunction({
+                    type: 'exponential',
+                    stops: [[12, 1]],
+                    base: 1.6,
+                    overflow: true
+                });
+
+                // the .toFixed(8) is to count for floating point precision errors
+                t.equal(f(1).toFixed(8), Math.pow(1.6, -11).toFixed(8));
+                t.equal(f(5).toFixed(8), Math.pow(1.6, -7).toFixed(8));
+                t.equal(f(11), 0.625);
+                t.equal(f(12), 1);
+                t.equal(f(13), 1.6);
+                t.equal(f(15).toFixed(8), (4.096).toFixed(8));
+                t.equal(f(20).toFixed(8), (42.94967296).toFixed(8));
+
+                t.end();
+            });
+
+            t.test('multiple stops linear', function(t) {
+                var f = MapboxGLFunction({
+                    type: 'exponential',
+                    stops: [[10, 1], [12, 2]],
+                    base: 1,
+                    overflow: true
+                });
+
+                t.equal(f(1), -3.5);
+                t.equal(f(8), 0);
+                t.equal(f(9), 0.5);
+                t.equal(f(10), 1);
+                t.equal(f(11), 1.5);
+                t.equal(f(12), 2);
+                t.equal(f(13), 2.5);
+                t.equal(f(14), 3);
+                t.equal(f(20), 6);
+
+                t.end();
+            });
+
+            // start repeat of other exponential tests to make sure they work with overflow
+            t.test('base', function(t) {
+                var f = MapboxGLFunction({
+                    type: 'exponential',
+                    stops: [[1, 2], [3, 6]],
+                    base: 2,
+                    overflow: true
+                });
+
+                t.equal(f(0), 1);
+                t.equal(f(1), 2);
+                t.equal(f(2), 30 / 9);
+                t.equal(f(3), 6);
+                t.equal(f(4), 12);
+
+                t.end();
+            });
+
+            t.test('stops', function(t) {
+                t.test('one element', function(t) {
+                    var f = MapboxGLFunction({
+                        type: 'exponential',
+                        stops: [[1, 2]],
+                        overflow: true
+                    });
+
+                    t.equal(f(0), 1);
+                    t.equal(f(1), 2);
+                    t.equal(f(2), 3);
+
+                    t.end();
+                });
+
+                t.test('two elements', function(t) {
+                    var f = MapboxGLFunction({
+                        type: 'exponential',
+                        stops: [[1, 2], [3, 6]],
+                        overflow: true
+                    });
+
+                    t.equal(f(0), 0);
+                    t.equal(f(1), 2);
+                    t.equal(f(2), 4);
+                    t.equal(f(3), 6);
+                    t.equal(f(4), 8);
+
+                    t.end();
+                });
+
+                t.test('three elements', function(t) {
+                    var f = MapboxGLFunction({
+                        type: 'exponential',
+                        stops: [[1, 2], [3, 6], [5, 10]],
+                        overflow: true
+                    });
+
+                    t.equal(f(0), 0);
+                    t.equal(f(1), 2);
+                    t.equal(f(2), 4);
+                    t.equal(f(3), 6);
+                    t.equal(f(4), 8);
+                    t.equal(f(5), 10);
+                    t.equal(f(6), 12);
+
+                    t.end();
+                });
+
+            });
+
+            t.test('zoom + data stops', function(t) {
+                t.test('one element', function(t) {
+                    var f = MapboxGLFunction({
+                        type: 'exponential',
+                        property: 'prop',
+                        stops: [[{ zoom: 1, value: 1 }, 2]],
+                        overflow: true
+                    });
+
+                    t.equal(f(0, { prop: 0 }), 2);
+                    t.equal(f(1, { prop: 0 }), 2);
+                    t.equal(f(2, { prop: 0 }), 2);
+                    t.equal(f(0, { prop: 1 }), 2);
+                    t.equal(f(1, { prop: 1 }), 2);
+                    t.equal(f(2, { prop: 1 }), 2);
+                    t.equal(f(0, { prop: 2 }), 2);
+                    t.equal(f(1, { prop: 2 }), 2);
+                    t.equal(f(2, { prop: 2 }), 2);
+
+                    t.end();
+                });
+
+                t.test('two elements', function(t) {
+                    var f = MapboxGLFunction({
+                        type: 'exponential',
+                        property: 'prop',
+                        base: 1,
+                        stops: [
+                            [{ zoom: 1, value: 0 }, 0],
+                            [{ zoom: 1, value: 2 }, 4],
+                            [{ zoom: 3, value: 0 }, 0],
+                            [{ zoom: 3, value: 2 }, 12]
+                        ],
+                        overflow: true
+                    });
+
+                    t.equal(f(0, { prop: 1 }), 2);
+                    t.equal(f(1, { prop: 1 }), 2);
+                    t.equal(f(2, { prop: 1 }), 4);
+                    t.equal(f(3, { prop: 1 }), 6);
+                    t.equal(f(4, { prop: 1 }), 6);
+
+                    t.equal(f(2, { prop: -1}), 0);
+                    t.equal(f(2, { prop: 0}), 0);
+                    t.equal(f(2, { prop: 2}), 8);
+                    t.equal(f(2, { prop: 3}), 8);
+
+                    t.end();
+                });
+
+                t.test('three elements', function(t) {
+                    var f = MapboxGLFunction({
+                        type: 'exponential',
+                        property: 'prop',
+                        base: 1,
+                        stops: [
+                            [{ zoom: 1, value: 0}, 0],
+                            [{ zoom: 1, value: 2}, 4],
+                            [{ zoom: 3, value: 0}, 0],
+                            [{ zoom: 3, value: 2}, 12],
+                            [{ zoom: 5, value: 0}, 0],
+                            [{ zoom: 5, value: 2}, 20]
+                        ],
+                        overflow: true
+                    });
+
+                    t.equal(f(0, { prop: 1 }), 2);
+                    t.equal(f(1, { prop: 1 }), 2);
+                    t.equal(f(2, { prop: 1 }), 4);
+
+                    t.end();
+                });
+
+                t.test('fractional zoom', function(t) {
+                    var f = MapboxGLFunction({
+                        type: 'exponential',
+                        property: 'prop',
+                        base: 1,
+                        stops: [
+                            [{ zoom: 1.9, value: 0 }, 4],
+                            [{ zoom: 2.1, value: 0 }, 8]
+                        ],
+                        overflow: true
+                    });
+
+                    t.equal(f(1.9, { prop: 1 }), 4);
+                    t.equal(f(2, { prop: 1 }), 6);
+                    t.equal(f(2.1, { prop: 1 }), 8);
+
+                    t.end();
+                });
+
+
+            });
+
+        });
 
     });
 


### PR DESCRIPTION
This PR lets you pass `overflow: true` to an exponential function to disable clamping and calculate a value based on the base.

Behavior is identical between defined stops; it only varies outside of the defined range.
## Linear functions

For linear functions it will use the slope between the two stops on the end of the range (or a slope of 1 if only one stop is given) and project out the line.

For example, the slope here is 1/2:

```
var f = MapboxGLFunction({
    type: 'exponential',
    stops: [[10, 1], [12, 2]],
    base: 1,
    overflow: true
});

t.equal(f(1), -3.5);
t.equal(f(8), 0);
t.equal(f(9), 0.5);
t.equal(f(10), 1);
t.equal(f(11), 1.5);
t.equal(f(12), 2);
t.equal(f(13), 2.5);
t.equal(f(14), 3);
t.equal(f(20), 6);
```
## Exponential functions

For exponential functions it will use the base passed and extrapolate out from the nearest end stop. 

For example, a single stop passed with a base of 2 means that it will double for each whole-number increase and halve for each whole-number decrease:

```
var f = MapboxGLFunction({
    type: 'exponential',
    stops: [[12, 1]],
    base: 2,
    overflow: true
});

t.equal(f(1), 1/2048);
t.equal(f(5), 1/128);
t.equal(f(11), 0.5);
t.equal(f(12), 1);
t.equal(f(13), 2);
t.equal(f(15), 8);
t.equal(f(20), 256);
```
## Launch Checklist
- [X] briefly describe the changes in this PR
- [X] write tests for all new functionality
- [ ] document any changes to public APIs -- I think this will need to be added to the style spec
- [ ] get a PR review

Spawned from a discussion with @lucaswoj in mapbox/mapbox-gl-js#3062
