### PR TITLE
Fall back to spec default if property function's target property is undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-function createFunction(parameters, defaultType, reference) {
+function createFunction(parameters, defaultType, specDefault) {
     var fun;
 
     if (!isFunctionDefinition(parameters)) {
@@ -42,10 +42,10 @@ function createFunction(parameters, defaultType, reference) {
             }
 
             for (var z in featureFunctions) {
-                featureFunctionStops.push([featureFunctions[z].zoom, createFunction(featureFunctions[z], type, reference)]);
+                featureFunctionStops.push([featureFunctions[z].zoom, createFunction(featureFunctions[z], type, specDefault)]);
             }
             fun = function(zoom, feature) {
-                return evaluateExponentialFunction({ stops: featureFunctionStops, base: parameters.base }, zoom)(zoom, feature, reference);
+                return evaluateExponentialFunction({ stops: featureFunctionStops, base: parameters.base }, zoom)(zoom, feature, specDefault);
             };
             fun.isFeatureConstant = false;
             fun.isZoomConstant = false;
@@ -58,7 +58,7 @@ function createFunction(parameters, defaultType, reference) {
             fun.isZoomConstant = false;
         } else {
             fun = function(zoom, feature) {
-                return innerFun(parameters, feature[parameters.property], reference);
+                return innerFun(parameters, feature[parameters.property], specDefault);
             };
             fun.isFeatureConstant = false;
             fun.isZoomConstant = true;
@@ -68,9 +68,9 @@ function createFunction(parameters, defaultType, reference) {
     return fun;
 }
 
-function evaluateCategoricalFunction(parameters, input, reference) {
-    if (input === undefined && reference && reference.default) {
-        return reference.default;
+function evaluateCategoricalFunction(parameters, input, specDefault) {
+    if (input === undefined && specDefault) {
+        return specDefault;
     }
 
     for (var i = 0; i < parameters.stops.length; i++) {
@@ -81,9 +81,9 @@ function evaluateCategoricalFunction(parameters, input, reference) {
     return parameters.stops[0][1];
 }
 
-function evaluateIntervalFunction(parameters, input, reference) {
-    if (input === undefined && reference && reference.default) {
-        return reference.default;
+function evaluateIntervalFunction(parameters, input, specDefault) {
+    if (input === undefined && specDefault) {
+        return specDefault;
     }
 
     for (var i = 0; i < parameters.stops.length; i++) {
@@ -92,9 +92,9 @@ function evaluateIntervalFunction(parameters, input, reference) {
     return parameters.stops[Math.max(i - 1, 0)][1];
 }
 
-function evaluateExponentialFunction(parameters, input, reference) {
-    if (input === undefined && reference && reference.default) {
-        return reference.default;
+function evaluateExponentialFunction(parameters, input, specDefault) {
+    if (input === undefined && specDefault) {
+        return specDefault;
     }
 
     var base = parameters.base !== undefined ? parameters.base : 1;
@@ -168,10 +168,10 @@ function isFunctionDefinition(value) {
 
 module.exports.isFunctionDefinition = isFunctionDefinition;
 
-module.exports.interpolated = function(parameters, reference) {
-    return createFunction(parameters, 'exponential', reference);
+module.exports.interpolated = function(parameters, specDefault) {
+    return createFunction(parameters, 'exponential', specDefault);
 };
 
-module.exports['piecewise-constant'] = function(parameters, reference) {
-    return createFunction(parameters, 'interval', reference);
+module.exports['piecewise-constant'] = function(parameters, specDefault) {
+    return createFunction(parameters, 'interval', specDefault);
 };

--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ function createFunction(parameters, defaultType, reference) {
             }
 
             for (var z in featureFunctions) {
-                featureFunctionStops.push([featureFunctions[z].zoom, createFunction(featureFunctions[z])]);
+                featureFunctionStops.push([featureFunctions[z].zoom, createFunction(featureFunctions[z], type, reference)]);
             }
             fun = function(zoom, feature) {
                 return evaluateExponentialFunction({ stops: featureFunctionStops, base: parameters.base }, zoom)(zoom, feature, reference);
@@ -93,7 +93,7 @@ function evaluateIntervalFunction(parameters, input, reference) {
 }
 
 function evaluateExponentialFunction(parameters, input, reference) {
-    if (input == undefined && reference) {
+    if (input === undefined && reference) {
         return reference.default;
     }
 

--- a/index.js
+++ b/index.js
@@ -69,7 +69,7 @@ function createFunction(parameters, defaultType, reference) {
 }
 
 function evaluateCategoricalFunction(parameters, input, reference) {
-    if (input === undefined && reference) {
+    if (input === undefined && reference && reference.default) {
         return reference.default;
     }
 
@@ -82,7 +82,7 @@ function evaluateCategoricalFunction(parameters, input, reference) {
 }
 
 function evaluateIntervalFunction(parameters, input, reference) {
-    if (input === undefined && reference) {
+    if (input === undefined && reference && reference.default) {
         return reference.default;
     }
 
@@ -93,7 +93,7 @@ function evaluateIntervalFunction(parameters, input, reference) {
 }
 
 function evaluateExponentialFunction(parameters, input, reference) {
-    if (input === undefined && reference) {
+    if (input === undefined && reference && reference.default) {
         return reference.default;
     }
 

--- a/index.js
+++ b/index.js
@@ -69,7 +69,7 @@ function createFunction(parameters, defaultType, specDefault) {
 }
 
 function evaluateCategoricalFunction(parameters, input, specDefault) {
-    if (input === undefined && specDefault) {
+    if (input === undefined && typeof specDefault !== 'undefined') {
         return specDefault;
     }
 
@@ -82,7 +82,7 @@ function evaluateCategoricalFunction(parameters, input, specDefault) {
 }
 
 function evaluateIntervalFunction(parameters, input, specDefault) {
-    if (input === undefined && specDefault) {
+    if (input === undefined && typeof specDefault !== 'undefined') {
         return specDefault;
     }
 
@@ -93,7 +93,7 @@ function evaluateIntervalFunction(parameters, input, specDefault) {
 }
 
 function evaluateExponentialFunction(parameters, input, specDefault) {
-    if (input === undefined && specDefault) {
+    if (input === undefined && typeof specDefault !== 'undefined') {
         return specDefault;
     }
 

--- a/test/test.js
+++ b/test/test.js
@@ -5,7 +5,7 @@ var MapboxGLFunction = require('../').interpolated;
 
 test('function types', function(t) {
 
-    t.test('contant', function(t) {
+    t.test('constant', function(t) {
 
         t.test('range types', function(t) {
 
@@ -107,6 +107,39 @@ test('function types', function(t) {
                 t.end();
             });
 
+            t.test('property', function(t) {
+                var f = MapboxGLFunction({
+                    type: 'exponential',
+                    stops: [[0, 0], [1000, 3000]],
+                    property: 'prop'
+                });
+
+                t.equal(f(10, { prop: 0 }), 0);
+                t.equal(f(10, { prop: 1 }), 3);
+                t.equal(f(10, { prop: 100 }), 300);
+                t.equal(f(10, { prop: 1000 }), 3000);
+                t.equal(f(10, { prop: 3000 }), 3000);
+                t.equal(f(10, { prop: undefined }), 3000);
+
+                t.end();
+            });
+
+            t.test('property with reference default', function(t) {
+                var f = MapboxGLFunction({
+                    type: 'exponential',
+                    stops: [[0, 0], [1000, 3000]],
+                    property: 'prop'
+                }, { default: 10 });
+
+                t.equal(f(10, { prop: 0 }), 0);
+                t.equal(f(10, { prop: 1 }), 3);
+                t.equal(f(10, { prop: 100 }), 300);
+                t.equal(f(10, { prop: 1000 }), 3000);
+                t.equal(f(10, { prop: 3000 }), 3000);
+                t.equal(f(10, { prop: undefined }), 10);
+
+                t.end();
+            });
         });
 
         t.test('zoom + data stops', function(t) {
@@ -152,6 +185,34 @@ test('function types', function(t) {
                 t.equal(f(2, { prop: 0}), 0);
                 t.equal(f(2, { prop: 2}), 8);
                 t.equal(f(2, { prop: 3}), 8);
+
+                t.end();
+            });
+
+            t.test('default', function(t) {
+                var f = MapboxGLFunction({
+                    type: 'exponential',
+                    property: 'prop',
+                    base: 1,
+                    stops: [
+                        [{ zoom: 15, value: 0}, 0],
+                        [{ zoom: 15, value: 1000}, 0],
+                        [{ zoom: 15.1, value: 0}, 0],
+                        [{ zoom: 15.1, value: 10}, 30],
+                        [{ zoom: 15.1, value: 1000}, 3000]]
+                }, { default: 3});
+
+                t.equal(f(15, { prop: 0 }), 0);
+                t.equal(f(15, { prop: 10 }), 0);
+                t.equal(f(15, { prop: 300 }), 0);
+                t.equal(f(15.2, { prop: 0 }), 0);
+                t.equal(f(15.2, { prop: 10 }), 30);
+                t.equal(f(15.2, { prop: undefined }), 3);
+                t.equal(f(15.2, { prop: 299 }), 897);
+                t.equal(f(16, { prop: 0 }), 0);
+                t.equal(f(16, { prop: 10 }), 30);
+                t.equal(f(16, { prop: undefined }), 3);
+                t.equal(f(16, { prop: 299 }), 897);
 
                 t.end();
             });

--- a/test/test.js
+++ b/test/test.js
@@ -129,7 +129,7 @@ test('function types', function(t) {
                     type: 'exponential',
                     stops: [[0, 0], [1000, 3000]],
                     property: 'prop'
-                }, { default: 10 });
+                }, 10);
 
                 t.equal(f(10, { prop: 0 }), 0);
                 t.equal(f(10, { prop: 1 }), 3);
@@ -221,7 +221,7 @@ test('function types', function(t) {
                         [{ zoom: 15.1, value: 0}, 0],
                         [{ zoom: 15.1, value: 10}, 30],
                         [{ zoom: 15.1, value: 1000}, 3000]]
-                }, { default: 3});
+                }, 3);
 
                 t.equal(f(15, { prop: 0 }), 0);
                 t.equal(f(15, { prop: 10 }), 0);
@@ -369,7 +369,7 @@ test('property', function(t) {
             type: 'categorical',
             stops: [['map', 'neat'], ['box', 'swell']],
             property: 'mapbox'
-        }, { default: 'cool' });
+        }, 'cool');
 
         t.equal(f({}, {mapbox: 'box'}), 'swell');
         t.equal(f({}, {mapbox: undefined}), 'cool');

--- a/test/test.js
+++ b/test/test.js
@@ -189,6 +189,27 @@ test('function types', function(t) {
                 t.end();
             });
 
+            t.test('three elements', function(t) {
+                var f = MapboxGLFunction({
+                    type: 'exponential',
+                    property: 'prop',
+                    base: 1,
+                    stops: [
+                        [{ zoom: 1, value: 0}, 0],
+                        [{ zoom: 1, value: 2}, 4],
+                        [{ zoom: 3, value: 0}, 0],
+                        [{ zoom: 3, value: 2}, 12],
+                        [{ zoom: 5, value: 0}, 0],
+                        [{ zoom: 5, value: 2}, 20]]
+                });
+
+                t.equal(f(0, { prop: 1 }), 2);
+                t.equal(f(1, { prop: 1 }), 2);
+                t.equal(f(2, { prop: 1 }), 4);
+
+                t.end();
+            });
+
             t.test('default', function(t) {
                 var f = MapboxGLFunction({
                     type: 'exponential',
@@ -213,27 +234,6 @@ test('function types', function(t) {
                 t.equal(f(16, { prop: 10 }), 30);
                 t.equal(f(16, { prop: undefined }), 3);
                 t.equal(f(16, { prop: 299 }), 897);
-
-                t.end();
-            });
-
-            t.test('three elements', function(t) {
-                var f = MapboxGLFunction({
-                    type: 'exponential',
-                    property: 'prop',
-                    base: 1,
-                    stops: [
-                        [{ zoom: 1, value: 0}, 0],
-                        [{ zoom: 1, value: 2}, 4],
-                        [{ zoom: 3, value: 0}, 0],
-                        [{ zoom: 3, value: 2}, 12],
-                        [{ zoom: 5, value: 0}, 0],
-                        [{ zoom: 5, value: 2}, 20]]
-                });
-
-                t.equal(f(0, { prop: 1 }), 2);
-                t.equal(f(1, { prop: 1 }), 2);
-                t.equal(f(2, { prop: 1 }), 4);
 
                 t.end();
             });
@@ -369,9 +369,10 @@ test('property', function(t) {
             type: 'categorical',
             stops: [['map', 'neat'], ['box', 'swell']],
             property: 'mapbox'
-        });
+        }, { default: 'cool' });
 
         t.equal(f({}, {mapbox: 'box'}), 'swell');
+        t.equal(f({}, {mapbox: undefined}), 'cool');
 
         t.end();
     });

--- a/test/test.js
+++ b/test/test.js
@@ -140,6 +140,23 @@ test('function types', function(t) {
 
                 t.end();
             });
+
+            t.test('property with 0 reference default', function(t) {
+                var f = MapboxGLFunction({
+                    type: 'exponential',
+                    stops: [[0, 0], [1000, 3000]],
+                    property: 'prop'
+                }, 0);
+
+                t.equal(f(10, { prop: 0 }), 0);
+                t.equal(f(10, { prop: 1 }), 3);
+                t.equal(f(10, { prop: 100 }), 300);
+                t.equal(f(10, { prop: 1000 }), 3000);
+                t.equal(f(10, { prop: 3000 }), 3000);
+                t.equal(f(10, { prop: undefined }), 0);
+
+                t.end();
+            });
         });
 
         t.test('zoom + data stops', function(t) {


### PR DESCRIPTION
This is an important feature for e.g. buildings styled with 

```
"fill-extrude-height": {
    "stops": [[0, 0], [1000, 1000]]
    "property": "height"
}
```

Without the ability to fall back to the spec default, features with no `height` property would extrude to 1000.

(It will also be very important that we land on a solution for https://github.com/mapbox/mapbox-gl-style-spec/issues/480 but, unlike this, not a release blocker IMO.)
