### PR TITLE
Add identity function type

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ function createFunction(parameters, defaultType) {
         fun.isZoomConstant = true;
 
     } else {
-        var zoomAndFeatureDependent = typeof parameters.stops[0][0] === 'object';
+        var zoomAndFeatureDependent = parameters.stops && typeof parameters.stops[0][0] === 'object';
         var featureDependent = zoomAndFeatureDependent || parameters.property !== undefined;
         var zoomDependent = zoomAndFeatureDependent || !featureDependent;
         var type = parameters.type || defaultType || 'exponential';
@@ -21,6 +21,8 @@ function createFunction(parameters, defaultType) {
             innerFun = evaluateIntervalFunction;
         } else if (type === 'categorical') {
             innerFun = evaluateCategoricalFunction;
+        } else if (type === 'identity') {
+            innerFun = evaluateIdentityFunction;
         } else {
             throw new Error('Unknown function type "' + type + '"');
         }
@@ -112,6 +114,10 @@ function evaluateExponentialFunction(parameters, input) {
     }
 }
 
+function evaluateIdentityFunction(parameters, input) {
+    return input;
+}
+
 
 function interpolate(input, base, inputLower, inputUpper, outputLower, outputUpper) {
     if (typeof outputLower === 'function') {
@@ -150,7 +156,7 @@ function interpolateArray(input, base, inputLower, inputUpper, outputLower, outp
 }
 
 function isFunctionDefinition(value) {
-    return typeof value === 'object' && value.stops;
+    return typeof value === 'object' && (value.stops || value.type === 'identity');
 }
 
 

--- a/test/test.js
+++ b/test/test.js
@@ -364,6 +364,40 @@ test('isConstant', function(t) {
         t.end();
     });
 
+    t.test('identity', function(t) {
+
+        t.test('array', function(t) {
+            var f = MapboxGLFunction({type: 'identity'});
+
+            t.deepEqual(f([]), []);
+            t.deepEqual(f([1]), [1]);
+            t.deepEqual(f([1, 2]), [1, 2]);
+
+            t.end();
+        });
+
+        t.test('number', function(t) {
+            var f = MapboxGLFunction({type: 'identity'});
+
+            t.equal(f(0), 0);
+            t.equal(f(1), 1);
+            t.equal(f(2), 2);
+
+            t.end();
+        });
+
+        t.test('string', function(t) {
+            var f = MapboxGLFunction({type: 'identity'});
+
+            t.equal(f(''), '');
+            t.equal(f('0'), '0');
+            t.equal(f('mapbox'), 'mapbox');
+
+            t.end();
+        });
+
+    });
+
     t.end();
 
 });


### PR DESCRIPTION
This PR adds an `identity` function type. This allows the use of property functions in some previously impossible ways:

 - passing an unbounded numeric value from a feature property to a style property 
 - passing a color from a feature property to a style property
 - passing an arbitrary string from a feature property to a style property

cc @jfirebaugh @mourner @mollymerp for review

resolves #20 

# Launch Checklist 

_These are things we can do post PR review_

 - [ ] update style spec documentation
 - [ ] update GL JS
 - [ ] open a ticket for parity with GL Native