### PR TITLE
Use categorical type by default when input values are strings

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,8 @@ function createFunction(parameters, defaultType) {
         var zoomAndFeatureDependent = parameters.stops && typeof parameters.stops[0][0] === 'object';
         var featureDependent = zoomAndFeatureDependent || parameters.property !== undefined;
         var zoomDependent = zoomAndFeatureDependent || !featureDependent;
-        var type = parameters.type || defaultType || 'exponential';
+        var inputType = parameters.stops && typeof (zoomAndFeatureDependent ? parameters.stops[0][0].property : parameters.stops[0][0]);
+        var type = parameters.type || defaultType || (inputType === 'string' ? 'categorical' : 'exponential');
 
         var innerFun;
         if (type === 'exponential') {

--- a/test/test.js
+++ b/test/test.js
@@ -45,6 +45,17 @@ test('function types', function(t) {
 
     t.test('exponential', function(t) {
 
+        t.test('is the default type for numeric inputs', function(t) {
+            var f = MapboxGLFunction({
+                stops: [[1, 2], [3, 6]],
+                base: 2
+            });
+
+            t.equal(f(2), 30 / 9);
+
+            t.end();
+        });
+
         t.test('base', function(t) {
             var f = MapboxGLFunction({
                 type: 'exponential',
@@ -255,6 +266,17 @@ test('function types', function(t) {
     });
 
     t.test('categorical', function(t) {
+
+        t.test('is the default type for string inputs', function(t) {
+            var f = MapboxGLFunction({
+                type: 'categorical',
+                stops: [['umpteen', 42]]
+            });
+
+            t.equal(f('umpteen'), 42);
+
+            t.end();
+        });
 
         t.test('one element', function(t) {
             var f = MapboxGLFunction({

--- a/test/test.js
+++ b/test/test.js
@@ -269,7 +269,6 @@ test('function types', function(t) {
 
         t.test('is the default type for string inputs', function(t) {
             var f = MapboxGLFunction({
-                type: 'categorical',
                 stops: [['umpteen', 42]]
             });
 


### PR DESCRIPTION
A common mistake when using functions is to fail to specify the `categorical` type when values in the input domain are strings. This need not be a mistake. We can do what the user intended by default. 

## After Merging

 - [x] open GL Native parity ticket
 - [ ] update GL JS `package.json`
 - [ ] update [style spec docs](https://www.mapbox.com/mapbox-gl-style-spec/#function-type)

fixes #19 

